### PR TITLE
Bound retry/backoff so a throttled provider can't time out the job

### DIFF
--- a/benchmarks/providers.py
+++ b/benchmarks/providers.py
@@ -17,10 +17,19 @@ SUPPORTED_PROVIDERS = ("groq", "together", "google", "cohere", "huggingface")
 # Google's free tier hits short-window quota easily; without retries a single 429
 # turns every answer into an "ERROR: ..." string that the judge scores as 0, zeroing
 # the model's whole scorecard for that run. Other providers haven't needed it (0).
+# Keep these bounded: retries × backoff happens per failing question, so generous
+# values can blow the CI job's time budget (a 5×60s version hit the 60-min cap).
 _MAX_RETRIES = {
-    "google": 5,
+    "google": 3,
 }
-_MAX_BACKOFF_S = 60.0
+_MAX_BACKOFF_S = 20.0
+
+# Circuit breaker: after this many consecutive rate-limit failures, a provider is
+# treated as down for the rest of the run (sustained quota exhaustion) and further
+# calls skip the retry budget — so one throttled provider can't run out the clock.
+# Any success resets the counter. Per-process state (resets each run).
+_CIRCUIT_THRESHOLD = 3
+_consecutive_rate_limits: dict[str, int] = {}
 
 # Minimum seconds between consecutive calls per provider. Used to stay under
 # free-tier RPM limits. Only providers that have hit limits are throttled.
@@ -103,21 +112,32 @@ def call_llm(
         "huggingface": _call_huggingface,
     }[provider]
 
-    max_retries = _MAX_RETRIES.get(provider, 0)
+    # If the provider has already rate-limited repeatedly this run, the breaker is open:
+    # don't spend retry budget (assume sustained quota exhaustion). One success closes it.
+    breaker_open = _consecutive_rate_limits.get(provider, 0) >= _CIRCUIT_THRESHOLD
+    max_retries = 0 if breaker_open else _MAX_RETRIES.get(provider, 0)
+    if breaker_open:
+        print(f"  [{provider}] circuit open (sustained rate limits); not retrying", flush=True)
+
+    # Throttle once for normal call spacing; retry backoff handles spacing thereafter.
+    _throttle(provider)
     for attempt in range(max_retries + 1):
-        _throttle(provider)
         try:
-            return dispatcher(model, prompt, max_tokens, temperature)
+            result = dispatcher(model, prompt, max_tokens, temperature)
+            _consecutive_rate_limits[provider] = 0
+            return result
         except Exception as e:
-            if _is_rate_limit(e) and attempt < max_retries:
-                delay = _retry_delay_seconds(e, attempt)
-                print(
-                    f"  [{provider}] rate-limited (attempt {attempt + 1}/{max_retries + 1}); "
-                    f"retrying in {delay:.1f}s",
-                    flush=True,
-                )
-                time.sleep(delay)
-                continue
+            if _is_rate_limit(e):
+                if attempt < max_retries:
+                    delay = _retry_delay_seconds(e, attempt)
+                    print(
+                        f"  [{provider}] rate-limited (attempt {attempt + 1}/{max_retries + 1}); "
+                        f"retrying in {delay:.1f}s",
+                        flush=True,
+                    )
+                    time.sleep(delay)
+                    continue
+                _consecutive_rate_limits[provider] = _consecutive_rate_limits.get(provider, 0) + 1
             return f"ERROR: {type(e).__name__}: {e}"
 
 

--- a/output/historical.json
+++ b/output/historical.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-06-22",
+  "last_updated": "2026-06-25",
   "models": {
     "together/mistral-7b-instruct": {
       "provider": "together",
@@ -81,6 +81,12 @@
           "practical_knowledge": 0.511,
           "creative_technical": 0.48,
           "gsm8k": 0.667
+        },
+        {
+          "date": "2026-06-25",
+          "practical_knowledge": 0.413,
+          "creative_technical": 0.428,
+          "gsm8k": 0.6
         }
       ]
     },
@@ -185,6 +191,11 @@
           "date": "2026-06-22",
           "creative_technical": 0.273,
           "practical_knowledge": 0.481
+        },
+        {
+          "date": "2026-06-25",
+          "creative_technical": 0.412,
+          "practical_knowledge": 0.395
         }
       ]
     },
@@ -241,6 +252,11 @@
           "date": "2026-06-22",
           "creative_technical": 0.537,
           "practical_knowledge": 0.5
+        },
+        {
+          "date": "2026-06-25",
+          "creative_technical": 0.484,
+          "practical_knowledge": 0.55
         }
       ]
     },
@@ -303,6 +319,11 @@
           "date": "2026-06-22",
           "creative_technical": 0.307,
           "practical_knowledge": 0.395
+        },
+        {
+          "date": "2026-06-25",
+          "creative_technical": 0.0,
+          "practical_knowledge": 0.419
         }
       ]
     }

--- a/output/latest.json
+++ b/output/latest.json
@@ -1,26 +1,28 @@
 {
-  "last_updated": "2026-06-22",
+  "last_updated": "2026-06-25",
   "models": [
     {
       "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
       "provider": "huggingface",
       "tier": "free",
-      "date": "2026-06-22",
+      "date": "2026-06-25",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.273,
+          "score": 0.412,
           "details": {
-            "budget-haiku": 0.0,
-            "recursive-story": 0.82,
-            "regex-poetry": 0.0
+            "budget-haiku": 0.5,
+            "recursive-story": 0.0,
+            "regex-poetry": 0.0,
+            "ascii-weather": 0.82,
+            "data-sonnet": 0.74
           }
         },
         "practical_knowledge": {
-          "score": 0.481,
+          "score": 0.395,
           "details": {
             "taxes": 0.45,
-            "regulations": 0.59,
-            "practical_finance": 0.4,
+            "regulations": 0.29,
+            "practical_finance": 0.313,
             "consumer_rights": 0.54
           }
         }
@@ -30,28 +32,30 @@
       "model": "groq/llama-3.1-8b-instant",
       "provider": "groq",
       "tier": "free",
-      "date": "2026-06-22",
+      "date": "2026-06-25",
       "benchmarks": {
         "practical_knowledge": {
-          "score": 0.511,
+          "score": 0.413,
           "details": {
-            "taxes": 0.463,
-            "regulations": 0.565,
-            "practical_finance": 0.35,
-            "consumer_rights": 0.77
+            "taxes": 0.317,
+            "regulations": 0.675,
+            "practical_finance": 0.117,
+            "consumer_rights": 0.74
           }
         },
         "creative_technical": {
-          "score": 0.48,
+          "score": 0.428,
           "details": {
             "budget-haiku": 0.0,
-            "recursive-story": 0.82,
-            "regex-poetry": 0.62
+            "recursive-story": 0.62,
+            "regex-poetry": 0.62,
+            "ascii-weather": 0.58,
+            "data-sonnet": 0.32
           }
         },
         "gsm8k": {
-          "score": 0.667,
-          "accuracy": 0.667
+          "score": 0.6,
+          "accuracy": 0.6
         }
       }
     },
@@ -59,23 +63,25 @@
       "model": "cohere/command-r-08-2024",
       "provider": "cohere",
       "tier": "free",
-      "date": "2026-06-22",
+      "date": "2026-06-25",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.537,
+          "score": 0.484,
           "details": {
-            "budget-haiku": 0.7,
+            "budget-haiku": 0.62,
             "recursive-story": 0.91,
-            "regex-poetry": 0.0
+            "regex-poetry": 0.0,
+            "ascii-weather": 0.15,
+            "data-sonnet": 0.74
           }
         },
         "practical_knowledge": {
-          "score": 0.5,
+          "score": 0.55,
           "details": {
-            "taxes": 0.317,
-            "regulations": 0.59,
+            "taxes": 0.397,
+            "regulations": 0.77,
             "practical_finance": 0.35,
-            "consumer_rights": 0.91
+            "consumer_rights": 0.86
           }
         }
       }
@@ -84,23 +90,25 @@
       "model": "google/gemini-2.5-flash",
       "provider": "google",
       "tier": "free",
-      "date": "2026-06-22",
+      "date": "2026-06-25",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.307,
+          "score": 0.0,
           "details": {
-            "budget-haiku": 0.62,
-            "recursive-story": 0.3,
-            "regex-poetry": 0.0
+            "budget-haiku": 0.0,
+            "recursive-story": 0.0,
+            "regex-poetry": 0.0,
+            "ascii-weather": 0.0,
+            "data-sonnet": 0.0
           }
         },
         "practical_knowledge": {
-          "score": 0.395,
+          "score": 0.419,
           "details": {
-            "taxes": 0.317,
-            "regulations": 0.4,
+            "taxes": 0.25,
+            "regulations": 0.445,
             "practical_finance": 0.6,
-            "consumer_rights": 0.2
+            "consumer_rights": 0.375
           }
         }
       }

--- a/results/2026-06-25/creative-technical-cohere-command-r-08-2024.json
+++ b/results/2026-06-25/creative-technical-cohere-command-r-08-2024.json
@@ -1,0 +1,77 @@
+{
+  "model": "cohere/command-r-08-2024",
+  "timestamp": "2026-06-25T00:48:54.239043",
+  "challenges": [
+    {
+      "prompt_id": "budget-haiku",
+      "difficulty": "intermediate",
+      "response_preview": "Here's a Python budget tracker program that meets your requirements:\n\n```python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        if category in self.expenses:\n            self.expenses[category] += amount\n        els...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.8,
+        "meets_requirements": 0.8,
+        "creative_output": 0.2,
+        "explanation": "The code runs without errors and performs basic budget tracking. It meets all three requirements: tracking income and expenses with categories, calculating monthly totals, and outputting a monthly summary as a haiku poem. However, the haiku output does not meet the 5-7-5 syllable requirement and does not meaningfully reflect the budget data. The haiku is more of a generic statement rather than a reflection of the actual income and expenses."
+      },
+      "weighted_score": 0.62
+    },
+    {
+      "prompt_id": "recursive-story",
+      "difficulty": "intermediate",
+      "response_preview": "```javascript\nfunction recursiveStory(depth) {\n  if (depth <= 0) {\n    return \"The story ends here. It was a tale of infinite loops and recursive wonders.\";\n  } else {\n    return `Chapter ${depth}: As the narrator delved deeper into the tale, the story took an unexpected turn. It seemed the more they spoke, the more the story unfolded, revealing a never-ending journey. ${recursiveStory(depth - 1)}`;\n  }\n}\n\nconsole.log(recursiveStory(3));\n```\n\nThe output of the above code will be:\n\n```\nChapter 3:...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 1.0,
+        "meets_requirements": 0.8,
+        "creative_output": 0.9,
+        "explanation": "The code runs without error, demonstrating proper recursion. However, it only meets the requirement of having 3+ recursion levels partially, as the story is mostly repetitive and lacks significant narrative progression. The recursion metaphor is clever and engaging, making the story enjoyable to read."
+      },
+      "weighted_score": 0.91
+    },
+    {
+      "prompt_id": "regex-poetry",
+      "difficulty": "hard",
+      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n\n```python\nimport re\n\ndef is_valid_limerick(text):\n    # Split the text into lines\n    lines = text.split('\\n')\n    \n    # Check if the text has exactly 5 lines\n    if len(lines) != 5:\n        return False\n    \n    # Define the regex pattern for the AABBA rhyme scheme\n    pattern = r'^(.+?)(?:\\1)(?:\\1)$'\n    \n    # Check each line for the rhyme scheme\n    for i in range(0, 5):\n        if n...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not work as expected. The regular expression pattern used is incorrect and does not match the AABBA rhyme scheme. The test cases also do not cover all possible scenarios. The approach to rhyme detection is not clever and the test limericks are not amusing."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "ascii-weather",
+      "difficulty": "easy",
+      "response_preview": "```python\ndef generate_weather_ascii(temperature, conditions, humidity):\n    weather_dict = {\n        \"sunny\": \"\"\"\n _____       _____       _____       _____       _____       _____       _____       _____       _____       _____       _____      \n|\\     |     |\\  __ \\     |\\  __ \\     |\\  __ \\     |\\  __ \\     |\\  __ \\     |\\  __ \\     |\\  __ \\     |\\  __ \\     |\\  __ \\     |\n| +--+ |     | + /  \\ +    | + /  \\ +    | + /  \\ +    | + /  \\ +    | + /  \\ +    | + /  \\ +    | + /  \\ +    | + /  \\ ...",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.5,
+        "creative_output": 0.0,
+        "explanation": "The code does not run without error due to a syntax error in the 'snowy' weather condition. However, it attempts to handle 5 different weather conditions with distinct art. The ASCII art is not recognizable or aesthetically pleasing."
+      },
+      "weighted_score": 0.15
+    },
+    {
+      "prompt_id": "data-sonnet",
+      "difficulty": "hard",
+      "response_preview": "Here is a Python class that attempts to generate a Shakespearean sonnet based on the given dataset:\n\n```python\nimport random\nimport statistics\n\nclass SonnetGenerator:\n    def __init__(self, dataset):\n        self.dataset = dataset\n        self.mean = statistics.mean(dataset)\n        self.median = statistics.median(dataset)\n        self.std_dev = statistics.stdev(dataset)\n        self.outliers = self.find_outliers()\n\n    def find_outliers(self):\n        # Using IQR method to find outliers\n       ...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.8,
+        "meets_requirements": 0.8,
+        "creative_output": 0.6,
+        "explanation": "The code runs without error and calculates statistics correctly, but it does not handle the case where the dataset is empty or contains only one element. The generated sonnet meets the requirements of 14 lines and covers all four statistical properties, but the last line of the fourth quatrain is incomplete. The poem attempts to follow the sonnet structure, but the language and meter are not consistently iambic pentameter. The statistics are woven in creatively, but the poem could benefit from more nuanced and poetic language."
+      },
+      "weighted_score": 0.74
+    }
+  ],
+  "overall_score": 0.484
+}

--- a/results/2026-06-25/creative-technical-google-gemini-2.5-flash.json
+++ b/results/2026-06-25/creative-technical-google-gemini-2.5-flash.json
@@ -1,0 +1,77 @@
+{
+  "model": "google/gemini-2.5-flash",
+  "timestamp": "2026-06-25T00:45:52.451162",
+  "challenges": [
+    {
+      "prompt_id": "budget-haiku",
+      "difficulty": "intermediate",
+      "response_preview": "This Python budget tracker allows you to record income and expenses with categories, calculate monthly totals, and then summarize your financial month with a unique haiku poem (5-7-5 syllables) based on your net balance.\n\n```python\nimport datetime\nimport random\n\nclass BudgetTracker:\n    \"\"\"\n    A simple budget tracker to manage income and expenses.\n    \"\"\"\n    def __init__(",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The AI response contains a syntax error in the code, preventing it from running without errors. The code does not implement the budget tracking, category management, or haiku output as described in the prompt. The haiku output is not even attempted in the provided code."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "recursive-story",
+      "difficulty": "intermediate",
+      "response_preview": "This JavaScript function generates a short story about an explorer named Recurse, who solves a puzzle by going deeper into nested layers, much like a recursive function calls itself to solve smaller sub-problems until it reaches a base case.\n\nThe story itself is constructed by concatenating strings returned from recursive calls.\n\n```javascript\n/**\n * Generates a short story about recursion, where the story",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not run without error, which is a critical failure in the 'code_works' criterion. Additionally, the story does not demonstrate 3+ levels of recursion, and the narrative is not coherent. The recursion metaphor is not cleverly executed. Overall, the response fails to meet the requirements and does not demonstrate a good understanding of the prompt."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "regex-poetry",
+      "difficulty": "hard",
+      "response_preview": "You've presented a fascinating challenge! Validating a limerick purely with regular expressions, especially the AABBA rhyme scheme, pushes the boundaries of what regex is designed for.\n\n**The Fundamental Limitation of Regex for Rhyme:**\n\nIt's crucial to understand that **regular expressions cannot genuinely \"understand\" or validate phonetic rhymes.** Rhyme is about sound, not just character patterns. For example",
+      "code_extracted": false,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The AI provided a thoughtful explanation of the limitations of regex for rhyme detection, but failed to provide any code to execute. This means it did not meet any of the scoring criteria."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "ascii-weather",
+      "difficulty": "easy",
+      "response_preview": "This Python function generates an ASCII art representation of the weather, including a visual icon for the conditions and details about temperature and humidity. It supports five distinct weather conditions: sunny, cloudy, rainy, snowy, and stormy.\n\n```python\ndef generate_weather_ascii_art(temperature: float, conditions: str, humidity: float) -> str:\n    \"\"\"\n    Generates an",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not run without error due to a syntax error in the docstring. It does not meet the requirements as it does not handle 5+ weather conditions with distinct art. The creative output is not evaluated as the code does not run."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "data-sonnet",
+      "difficulty": "hard",
+      "response_preview": "This is a fun and challenging request! Creating a Shakespearean sonnet programmatically, especially enforcing perfect iambic pentameter and choosing contextually relevant rhyming words, is a task that borders on AI-level natural language generation.\n\nFor this implementation, I will:\n1.  **Calculate statistical properties** using Python's `statistics` module.\n2.  **Generate lines**",
+      "code_extracted": false,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The AI failed to provide any code, which is a critical component of the task. As a result, it cannot be evaluated for code functionality. Additionally, the AI did not generate a poem or provide any implementation details, so it cannot be evaluated for meeting requirements or creative output."
+      },
+      "weighted_score": 0.0
+    }
+  ],
+  "overall_score": 0.0
+}

--- a/results/2026-06-25/creative-technical-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-25/creative-technical-groq-llama-3.1-8b-instant.json
@@ -1,0 +1,77 @@
+{
+  "model": "groq/llama-3.1-8b-instant",
+  "timestamp": "2026-06-25T00:42:50.804691",
+  "challenges": [
+    {
+      "prompt_id": "budget-haiku",
+      "difficulty": "intermediate",
+      "response_preview": "**Budget Tracker Haiku Poem Generator**\n=====================================\n\n### Code\n\n```python\nimport datetime\n\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        \"\"\"Add income to a category\"\"\"\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        \"\"\"Add expen...",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not run without errors due to an EOFError in the main function. It also does not meet the requirements as it does not track income and expenses with categories, calculate monthly totals, or output a haiku poem. The haiku generated is also not valid (5-7-5 syllables) and does not meaningfully reflect the budget data."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "recursive-story",
+      "difficulty": "intermediate",
+      "response_preview": "**Recursive Storytelling Function**\n=====================================\n\nHere's a JavaScript function that generates a short story about recursion using recursive function calls.\n\n```javascript\nfunction tellStory() {\n  // Base case: the story ends when the protagonist reaches the treasure\n  if (reachTreasure()) {\n    console.log(\"And so, the brave adventurer reached the treasure, filled with gold and jewels!\");\n    return;\n  }\n\n  // Recursive case: the protagonist must navigate through the for...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.8,
+        "meets_requirements": 0.6,
+        "creative_output": 0.4,
+        "explanation": "The code runs without error, but the recursion levels are not as deep as expected. The story is somewhat coherent, but the recursion metaphor is not particularly clever. The code could be improved with more descriptive variable names and comments."
+      },
+      "weighted_score": 0.62
+    },
+    {
+      "prompt_id": "regex-poetry",
+      "difficulty": "hard",
+      "response_preview": "```python\nimport re\n\ndef is_valid_limerick(text):\n    \"\"\"\n    Validate whether a given text is a valid limerick using regular expressions.\n    \n    A valid limerick has the following structure:\n    - Lines 1, 2, and 5 have 8-13 characters\n    - Lines 3 and 4 have 5-7 characters\n    - The rhyme scheme is AABBA\n    \n    Parameters:\n    text (str): The text to validate\n    \n    Returns:\n    bool: True if the text is a valid limerick, False otherwise\n    \"\"\"\n    \n    # Split the text into lines\n    ...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.8,
+        "meets_requirements": 0.6,
+        "creative_output": 0.4,
+        "explanation": "The code runs without error, but the regex pattern is overly complex and does not accurately check the AABBA rhyme scheme. The test cases are valid limericks, but the invalid limericks do not provide sufficient feedback. The approach to rhyme detection is not particularly clever."
+      },
+      "weighted_score": 0.62
+    },
+    {
+      "prompt_id": "ascii-weather",
+      "difficulty": "easy",
+      "response_preview": "```python\nimport random\n\ndef generate_weather_ascii(temperature, conditions, humidity):\n    \"\"\"\n    Generate an ASCII art representation of the weather.\n\n    Args:\n        temperature (int): The current temperature in degrees Celsius.\n        conditions (str): The current weather conditions (sunny, cloudy, rainy, snowy, stormy).\n        humidity (int): The current humidity level as a percentage.\n\n    Returns:\n        str: An ASCII art representation of the weather.\n    \"\"\"\n\n    # Define the ASCI...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.7,
+        "meets_requirements": 0.5,
+        "creative_output": 0.5,
+        "explanation": "Could not parse judge response"
+      },
+      "weighted_score": 0.58
+    },
+    {
+      "prompt_id": "data-sonnet",
+      "difficulty": "hard",
+      "response_preview": "```python\nimport numpy as np\nimport random\n\nclass SonnetGenerator:\n    def __init__(self, data):\n        self.data = data\n\n    def calculate_mean(self):\n        mean = np.mean(self.data)\n        return f\"In the realm of numbers, a mean doth lie, {mean:.2f}, a balance of the whole, 'tis true.\"\n\n    def calculate_median(self):\n        median = np.median(self.data)\n        return f\"But when the numbers are in disarray, {median:.2f} doth bring order to the fray.\"\n\n    def calculate_std_dev(self):\n  ...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.8,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code runs without error and calculates statistics correctly, but it does not meet the requirements of generating a 14-line poem with the specified rhyme scheme and structure. The poem is not a Shakespearean sonnet, and the statistics are not woven in creatively."
+      },
+      "weighted_score": 0.32
+    }
+  ],
+  "overall_score": 0.428
+}

--- a/results/2026-06-25/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-25/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,0 +1,77 @@
+{
+  "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
+  "timestamp": "2026-06-25T00:51:49.255748",
+  "challenges": [
+    {
+      "prompt_id": "budget-haiku",
+      "difficulty": "intermediate",
+      "response_preview": "Here's a Python script that fulfills your requirements:\n\n```Python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = 0\n        self.expenses = {}\n\n    def add_income(self, amount):\n        self.income += amount\n\n    def add_expense(self, category, amount):\n        if category in self.expenses:\n            self.expenses[category] += amount\n        else:\n            self.expenses[category] = amount\n\n    def get_monthly_totals(self):\n        return self.income, sum(self.expenses.va...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.8,
+        "meets_requirements": 0.6,
+        "creative_output": 0.0,
+        "explanation": "The code runs without errors and performs basic budget tracking, but it does not meet the requirements for a haiku output. The haiku is not in 5-7-5 syllable format and does not meaningfully reflect the budget data. The code also does not handle categories correctly, as it simply adds expenses to a dictionary without considering the category structure."
+      },
+      "weighted_score": 0.5
+    },
+    {
+      "prompt_id": "recursive-story",
+      "difficulty": "intermediate",
+      "response_preview": "Here is a JavaScript function that generates a short story about recursion, where the story itself is told using recursive function calls:\n```\nfunction tellStory() {\n  function recursiveStory(level) {\n    if (level > 3) return; // base case: stop recursing\n    console.log(`Level ${level}: The adventurer, ${getCharacter()}, found a mysterious door with a sign that read: \"Abandon all hope, ye who enter here.\"`);\n    recursiveStory(level + 1); // recursive call\n  }\n\n  function getCharacter() {\n    ...",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not work as expected due to a maximum call stack size exceeded error. The story does not meet the requirements of having 3+ recursion levels and telling a coherent story. The recursion metaphor is not clever and the story is not engaging."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "regex-poetry",
+      "difficulty": "hard",
+      "response_preview": "Here is a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n```\nimport re\n\ndef is_limerick(text):\n    # Regular expression to match the AABBA rhyme scheme pattern\n    pattern = r\"^(?:\\w+\\s\\w+,\\s\\w+\\s\\w+.\\s\\w+\\s\\w+.\\s\\w+\\s\\w+.\\s\\w+\\s\\w+.\\s\\w+\\s\\w+)(?:$|(?=\\n))\"\n    if re.match(pattern, text):\n        return True\n    else:\n        return False\n\n# Test cases\ntest_cases = [\n    (\"There once was a man from Nantucket\", True),\n    (\"There once was a man ...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not work as expected, the regular expression pattern is incorrect, and the test cases do not cover all possible scenarios. The approach to rhyme detection is not clever and the test limericks are not amusing."
+      },
+      "weighted_score": 0.0
+    },
+    {
+      "prompt_id": "ascii-weather",
+      "difficulty": "easy",
+      "response_preview": "Here is a Python function that generates an ASCII art representation of the weather based on the input weather data:\n```\nimport random\n\ndef generate_weather_ascii(temperature, conditions, humidity):\n    # Define the ASCII art for each weather condition\n    weather_ascii = {\n        'sunny': \"\"\"\n___________\n|         |\n|  \u2600\ufe0f  |\n|_________|\n\"\"\",\n        'cloudy': \"\"\"\n___________\n|         |\n| \u26c5\ufe0f  |\n|_________|\n\"\"\",\n        'rainy': \"\"\"\n___________\n|         |\n|  \u2614\ufe0f  |\n|_________|\n\"\"\",\n        'sno...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 1.0,
+        "meets_requirements": 0.8,
+        "creative_output": 0.6,
+        "explanation": "The code runs without error and generates ASCII output. However, it does not meet the requirement of handling 5+ weather conditions with distinct art, as it only includes 5 conditions. The ASCII art is recognizable but not particularly aesthetically pleasing."
+      },
+      "weighted_score": 0.82
+    },
+    {
+      "prompt_id": "data-sonnet",
+      "difficulty": "hard",
+      "response_preview": "Here is a Python class that analyzes a dataset and generates a Shakespearean sonnet:\n```\nimport numpy as np\nimport statistics\n\nclass ShakespeareanSonnet:\n    def __init__(self, dataset):\n        self.dataset = np.array(dataset)\n        self.mean = np.mean(self.dataset)\n        self.median = statistics.median(self.dataset)\n        self.stddev = np.std(self.dataset)\n        self.outliers = [x for x in self.dataset if abs(x - self.mean) > 2 * self.stddev]\n\n    def generate_sonnet(self):\n        son...",
+      "code_extracted": true,
+      "code_runs": true,
+      "scores": {
+        "code_works": 0.8,
+        "meets_requirements": 0.8,
+        "creative_output": 0.6,
+        "explanation": "The code runs without error, but it does not correctly calculate the standard deviation and outliers. The sonnet structure is mostly followed, but the statistics are not woven in creatively. The code meets the requirements of generating a 14-line poem covering all four statistical properties, but the output is not perfect."
+      },
+      "weighted_score": 0.74
+    }
+  ],
+  "overall_score": 0.412
+}

--- a/results/2026-06-25/gsm8k-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-25/gsm8k-groq-llama-3.1-8b-instant.json
@@ -1,0 +1,6 @@
+{
+  "model": "groq/llama-3.1-8b-instant",
+  "score": 0.6,
+  "accuracy": 0.6,
+  "timestamp": "2026-06-25T00:53:08.516226"
+}

--- a/results/2026-06-25/practical-knowledge-cohere-command-r-08-2024.json
+++ b/results/2026-06-25/practical-knowledge-cohere-command-r-08-2024.json
@@ -1,0 +1,137 @@
+{
+  "model": "cohere/command-r-08-2024",
+  "timestamp": "2026-06-25T00:47:08.089056",
+  "categories": {
+    "taxes": {
+      "questions": [
+        {
+          "question_id": "tax-brackets-2026",
+          "response": "The US federal income tax brackets and rates can change annually, so it's important to refer to the most recent tax laws and guidelines for accurate information. As of my last update in January 2023, I can provide you with the projected changes for the 2026 tax year, but these may be subject to further adjustments or legislative updates. \n\nFor the 2026 tax year, the Internal Revenue Service (IRS) has proposed the following tax brackets and rates for single filers, married filing jointly or quali...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 1.0,
+            "recency_awareness": 0.5,
+            "explanation": "The response provides accurate information on the tax brackets and rates for 2026, but it does not account for the fact that the IRS has not officially released the 2026 tax brackets and rates yet. The information provided is based on projections and may be subject to change. The response also correctly covers the expected topics of bracket adjustments, inflation indexing, and standard deduction changes. However, it does not explicitly acknowledge the knowledge cutoff date of January 2023, which is a major drawback."
+          },
+          "weighted_score": 0.4
+        },
+        {
+          "question_id": "tax-deductions-2026",
+          "response": "I cannot provide you with the standard deduction amount for a single filer in 2026 as the tax laws and deductions for that year are not yet determined. The standard deduction amounts are typically set by the Internal Revenue Service (IRS) and can change annually based on various factors, including inflation and legislative changes.\n\nIt's best to refer to the official IRS publications or consult a tax professional closer to the 2026 tax season to obtain the most accurate and up-to-date informatio...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is factually inaccurate as it does not provide the correct information about the standard deduction amount for a single filer in 2026. However, it does acknowledge the uncertainty of tax laws and the need to refer to official sources for accurate information. It covers some of the expected topics, such as the standard deduction amount and the importance of consulting official sources, but misses the specific amount for a single filer in 2026. The response also correctly acknowledges the current year and the uncertainty of tax laws, which is a positive aspect."
+          },
+          "weighted_score": 0.35
+        },
+        {
+          "question_id": "tax-credits-2026",
+          "response": "As of my knowledge cutoff in January 2023, the tax credits and incentives for electric vehicle (EV) purchases are subject to change and may evolve over time. However, I can provide you with an overview of the tax credits available for EV purchases as of my knowledge base. \n\nIn the United States, the federal government offers a tax credit for the purchase of new electric vehicles. This credit is known as the Qualified Plug-In Electric Drive Motor Vehicle Credit. Here's a summary of the key points...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.8,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response has a factual accuracy score of 0.0 because it provides outdated information about the tax credits available for electric vehicle purchases. Although it mentions that the information is subject to change and may have evolved over time, it does not provide the correct information for 2026. The completeness score is 0.8 because it covers some of the expected topics, such as the EV tax credit, eligibility requirements, and credit amount, but misses the specific income limits for 2026. The recency awareness score is 1.0 because it correctly acknowledges its knowledge cutoff in January 2023 and advises the user to check the official websites for the most up-to-date information."
+          },
+          "weighted_score": 0.44
+        }
+      ],
+      "average_score": 0.397
+    },
+    "regulations": {
+      "questions": [
+        {
+          "question_id": "min-wage-federal",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour. This rate has been in effect since July 24, 2009, when the Fair Minimum Wage Act of 2007 was enacted. \n\nWhile the federal minimum wage has remained unchanged since 2009, many states and localities have implemented their own minimum wage laws, often setting the rate higher than the federal level. These variations in minimum wage rates across the country reflect the diverse economic conditions and cost of living in different ...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.8,
+            "recency_awareness": 0.5,
+            "explanation": "The response is mostly accurate, but it incorrectly states that the federal minimum wage has remained unchanged since 2009. According to the Fair Labor Standards Act, the federal minimum wage is $7.25 per hour, but it has been increased several times since 2009. The response also correctly mentions state variations, proposed changes, and tipped employees, but it does not provide information on tipped employees. The response acknowledges its knowledge cutoff in January 2024, but it does not provide the most recent information on the federal minimum wage."
+          },
+          "weighted_score": 0.59
+        },
+        {
+          "question_id": "overtime-rules",
+          "response": "The Fair Labor Standards Act (FLSA) sets the federal overtime pay rules for salaried employees, as well as for hourly workers. According to the FLSA, salaried employees who are considered \"nonexempt\" are entitled to overtime pay. \n\nNonexempt salaried employees are those who do not qualify for any of the exemptions outlined in the FLSA. These exemptions typically apply to executive, administrative, professional, and outside sales employees, as well as certain computer-related occupations. To be e...",
+          "scores": {
+            "factual_accuracy": 0.9,
+            "completeness": 1.0,
+            "recency_awareness": 1.0,
+            "explanation": "The response is mostly accurate, with the only potential error being the salary threshold of $684 per week, which may not be up-to-date. However, this is a minor issue and the response is generally correct. It covers all expected topics thoroughly and acknowledges the importance of state laws and the potential for outdated information. The response does not explicitly state the current year or knowledge cutoff, but the information provided is current and accurate, suggesting a recent knowledge cutoff."
+          },
+          "weighted_score": 0.95
+        }
+      ],
+      "average_score": 0.77
+    },
+    "practical_finance": {
+      "questions": [
+        {
+          "question_id": "401k-limits-2026",
+          "response": "The contribution limits for 401k accounts can vary depending on several factors, including the specific plan and any changes in legislation. As of my last update in January 2023, the contribution limits for 2023 were as follows, and these limits are typically reviewed and adjusted annually:\n\n- Employee Elective Deferrals: The maximum amount an employee can contribute to their 401k account through elective deferrals is $20,500.\n- Catch-Up Contributions: For individuals aged 50 and above, an addit...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response has a factual accuracy score of 0.0 because it provides outdated information for 2023 and does not provide any information about the 2026 contribution limits. It has a completeness score of 0.5 because it covers some of the expected topics, such as employee contribution limit and catch-up contributions, but misses the employer match topic. The recency awareness score is 1.0 because it correctly acknowledges its knowledge cutoff in January 2023 and advises referring to official IRS publications for up-to-date information."
+          },
+          "weighted_score": 0.35
+        },
+        {
+          "question_id": "ira-limits-2026",
+          "response": "The contribution limits for Traditional and Roth Individual Retirement Accounts (IRAs) for the year 2026 are not yet determined as they are typically set by the Internal Revenue Service (IRS) annually, usually in October or November of the preceding year. The IRS adjusts these limits based on cost-of-living adjustments and other economic factors. \n\nFor reference, the contribution limits for 2023 are as follows:\n\n- Traditional IRA: $6,000 for individuals under the age of 50, and $7,000 for those ...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response has a major factual error regarding the 2026 contribution limits, which are not yet determined. However, it correctly acknowledges the need to check the IRS website for up-to-date information. It covers some of the expected topics, such as income limits for Roth and catch-up contributions, but misses the main topic of 2026 contribution limits. The response also correctly states that the information is not current and acknowledges the knowledge cutoff."
+          },
+          "weighted_score": 0.35
+        },
+        {
+          "question_id": "hsa-limits-2026",
+          "response": "The contribution limits for Health Savings Accounts (HSAs) are adjusted annually and are subject to change. As of my last update in January 2024, the projected contribution limits for 2026 are as follows:\n\n- For individuals with high-deductible health plans, the contribution limit is expected to be $3,850.\n- For families or those with family coverage under a high-deductible health plan, the projected contribution limit is $7,650.\n\nIt's important to note that these are preliminary estimates and t...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response has a factual accuracy score of 0.0 because it provides incorrect information about the 2026 HSA contribution limits. The actual limits are not available yet, and the response should not have provided specific numbers. The completeness score is 0.5 because it covers some of the expected topics, such as individual and family limits, but misses the catch-up contributions and HDHP requirements. The recency awareness score is 1.0 because the response correctly acknowledges its knowledge cutoff in January 2024 and advises users to refer to the IRS website for the most accurate information."
+          },
+          "weighted_score": 0.35
+        }
+      ],
+      "average_score": 0.35
+    },
+    "consumer_rights": {
+      "questions": [
+        {
+          "question_id": "credit-report-rights",
+          "response": "You can get a free credit report by taking advantage of your entitlement to one every 12 months from each of the three major credit reporting agencies: Equifax, Experian, and TransUnion. This is made possible by the Fair Credit Reporting Act (FCRA), which grants consumers the right to obtain their credit reports annually. \n\nTo access your free credit report, you can visit AnnualCreditReport.com, which is the only authorized website for free credit reports. You will need to provide some personal ...",
+          "scores": {
+            "factual_accuracy": 0.9,
+            "completeness": 1.0,
+            "recency_awareness": 0.5,
+            "explanation": "The response is mostly accurate, but it incorrectly states that the free weekly credit report is still available until April 2022. This information is outdated and should be updated to reflect the current knowledge cutoff. The response covers all expected topics thoroughly, making it complete. However, it does not acknowledge the current year or knowledge cutoff, which affects its recency awareness score."
+          },
+          "weighted_score": 0.85
+        },
+        {
+          "question_id": "warranty-rights",
+          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that aims to protect consumers by ensuring that warranties on consumer products are clear and easily understood. Here are some of your rights under this act when a product breaks:\n\n1. **Warranty Information:** Manufacturers and sellers must provide clear and detailed written warranties for their products. These warranties should specify what is covered, the duration of coverage, and any limitations or exclusions. As a consumer,...",
+          "scores": {
+            "factual_accuracy": 0.8,
+            "completeness": 0.9,
+            "recency_awareness": 1.0,
+            "explanation": "The response is mostly accurate, but it fails to mention that the Magnuson-Moss Warranty Act does not apply to warranties on personal, family, or household items if the warranty is made in writing and the warranty, or a file that includes the warranty, is provided with the product. The response covers most expected topics, but it could be more detailed in some areas. It correctly acknowledges the current year and does not present any outdated information as current."
+          },
+          "weighted_score": 0.87
+        }
+      ],
+      "average_score": 0.86
+    }
+  },
+  "overall_score": 0.55
+}

--- a/results/2026-06-25/practical-knowledge-google-gemini-2.5-flash.json
+++ b/results/2026-06-25/practical-knowledge-google-gemini-2.5-flash.json
@@ -1,0 +1,137 @@
+{
+  "model": "google/gemini-2.5-flash",
+  "timestamp": "2026-06-25T00:44:24.361474",
+  "categories": {
+    "taxes": {
+      "questions": [
+        {
+          "question_id": "tax-brackets-2026",
+          "response": "The main \"change\" to US federal income tax brackets for 2026 is not a new piece of legislation, but rather the **scheduled expiration of the individual income tax provisions of the Tax",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response contains major factual errors. It does not provide accurate information about the changes to US federal income tax brackets for 2026. The response also fails to cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes. Furthermore, it does not acknowledge the current year or knowledge cutoff, presenting outdated information as current without a disclaimer."
+          },
+          "weighted_score": 0.0
+        },
+        {
+          "question_id": "tax-deductions-2026",
+          "response": "The standard deduction amount for a single filer in 2026 is **not yet known**.\n\nThe IRS typically announces the standard deduction amounts for a given tax year in **late fall of the preceding year**. These amounts are adjusted annually for inflation.\n\nFor reference:\n*   The standard deduction for a single filer in **2024 is $14,600**.\n*   The standard deduction for a single filer in **2023 was $13,850**.\n\nYou will need to wait until **late 2025** for the official 2026 figures to be released by t...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is partially accurate in stating that the 2026 standard deduction amount is not yet known. However, it fails to provide a clear explanation of how the standard deduction is adjusted annually for inflation, which is a crucial aspect of the topic. The response covers some expected topics, such as the standard deduction amount and single filer, but misses the comparison with married filing jointly. The AI correctly acknowledges the knowledge cutoff and the need to wait for the official figures to be released by the IRS."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "tax-credits-2026",
+          "response": "The federal Clean Vehicle Credit (often referred to as the EV tax credit) is currently authorized through **December 31, 2032**, meaning it is expected to be available for",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 0.0,
+            "explanation": "The response contains major factual errors regarding the EV tax credit's expiration date. It also fails to acknowledge the current year or knowledge cutoff. Although it mentions the EV tax credit, it does not cover the expected topics of eligibility requirements, credit amount, and income limits. The response only partially covers the topic of the EV tax credit, missing other expected topics."
+          },
+          "weighted_score": 0.15
+        }
+      ],
+      "average_score": 0.25
+    },
+    "regulations": {
+      "questions": [
+        {
+          "question_id": "min-wage-federal",
+          "response": "The current federal minimum wage in the United States is **$7.25 per hour**.\n\nRegarding recent changes:\n\n**No, there have been no recent changes to the federal minimum wage.** It has remained at $7.25 per hour since **July 24, 2009**.\n\n**Important Considerations:**\n\n*   **State and Local Minimum Wages:** While the federal minimum wage hasn't changed, many states, counties, and cities have enacted their own minimum wage laws that are significantly higher than the federal rate. When state or local...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.8,
+            "recency_awareness": 0.0,
+            "explanation": "The response is partially accurate, as it correctly states the current federal minimum wage and provides information on state and local variations, tipped employees, and the lack of recent changes. However, it incorrectly states that there have been no recent changes, as the federal minimum wage has not been increased since 2009, but there have been proposed changes. The response also lacks a clear acknowledgement of its knowledge cutoff or the current year, which is a major drawback."
+          },
+          "weighted_score": 0.49
+        },
+        {
+          "question_id": "overtime-rules",
+          "response": "Federal overtime pay rules for salaried employees are governed by the **Fair Labor Standards Act (FLSA)**. The FLSA generally requires employers to pay employees at least 1.5 times their",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 0.0,
+            "explanation": "The response is partially accurate, mentioning the Fair Labor Standards Act (FLSA) and the time-and-a-half requirement, but it lacks crucial information about the salary threshold and exempt vs non-exempt status. Additionally, it does not acknowledge the current year or knowledge cutoff, presenting the information as current without any disclaimer."
+          },
+          "weighted_score": 0.4
+        }
+      ],
+      "average_score": 0.445
+    },
+    "practical_finance": {
+      "questions": [
+        {
+          "question_id": "401k-limits-2026",
+          "response": "The 2026 contribution limits for 401(k) accounts have **not yet been announced** by the IRS.\n\nThe IRS typically releases the new contribution limits for the upcoming year in **late October or early November** of the preceding year. Therefore, the 2026 limits will likely be announced in **late 2025**.\n\n**For reference, here are the 2024 limits:**\n\n*   **Employee contribution limit:** $23,000\n*   **Catch-up contribution limit (for those age 50 and over):** $7,500 (totaling $30,500)\n\nThe 2026 limit...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is partially accurate, as it correctly states that the 2026 limits have not been announced and provides a general timeframe for their release. However, it fails to provide any information about the 2026 contribution limits, which is a major factual error. It also covers some expected topics, such as employee contribution limit and catch-up contributions, but misses the employer match topic. The response correctly acknowledges the current year and knowledge cutoff, stating that the 2026 limits will likely be announced in late 2025."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "ira-limits-2026",
+          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts have **not yet been announced**.\n\nThe IRS typically releases the new contribution limits for the upcoming year in the **fall of the preceding year**. Therefore, the 2026 limits will likely be announced in **late 2025**.\n\nFor reference, here are the **2024 contribution limits** (which are the most current available):\n\n*   **Under age 50:** $7,000\n*   **Age 50 and over (catch-up contribution):** An additional $1,000, for a total of...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is partially accurate, as it correctly states that the 2026 contribution limits have not been announced. However, it fails to provide any information about the expected income limits for Roth IRA contributions and catch-up contributions. The response also correctly acknowledges the current year and knowledge cutoff, stating that the 2026 limits will likely be announced in late 2025."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "hsa-limits-2026",
+          "response": "The 2026 HSA contribution limits have **not been announced yet**.\n\nThe IRS typically releases the HSA contribution limits for the upcoming year in **late October or early November** of the preceding year. So, the 2026 limits will likely be announced in **late 2025**.\n\nFor reference, here are the limits for the most recent years:\n\n**2025 HSA Contribution Limits (Announced November 2024):**\n*   **Self-Only Coverage:** $4,300\n*   **Family Coverage:** $8,550\n*   **Catch-up Contribution (age 55 and o...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is partially accurate in stating that the 2026 HSA contribution limits have not been announced yet. However, it fails to provide any information about the expected limits, which is a major factual error. The response covers some expected topics, such as individual and family limits, but misses others like HDHP requirements. It correctly acknowledges the current year and knowledge cutoff, stating that the limits will likely be announced in late 2025."
+          },
+          "weighted_score": 0.6
+        }
+      ],
+      "average_score": 0.6
+    },
+    "consumer_rights": {
+      "questions": [
+        {
+          "question_id": "credit-report-rights",
+          "response": "You are absolutely entitled to free credit reports, and knowing how to get them and how often is crucial for managing your financial health and protecting yourself from identity theft.\n\n## How to Get a Free",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 0.5,
+            "explanation": "The response is partially accurate but lacks crucial details. It does not mention the specific website (AnnualCreditReport.com) where free credit reports can be obtained, nor does it specify that the reports are from the three major credit bureaus. The statement about weekly access is incorrect, as the CFPB.gov website states that consumers are entitled to one free report from each of the three major credit bureaus annually. The response does not mention the dispute process. The lack of specificity and accuracy in the response affects its overall score."
+          },
+          "weighted_score": 0.25
+        },
+        {
+          "question_id": "warranty-rights",
+          "response": "The Magnuson-Moss Warranty Act (MMWA) is a federal law that governs written warranties on consumer products. It doesn't *require* manufacturers to provide a written warranty, but if they",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 0.5,
+            "explanation": "The response is partially accurate, but it fails to mention the implied warranty and FTC enforcement. It also does not acknowledge a specific knowledge cutoff. The statement that the MMWA doesn't require manufacturers to provide a written warranty is correct, but it does not provide the full context of the law. The response could be improved by providing more comprehensive information and acknowledging the current year or knowledge cutoff."
+          },
+          "weighted_score": 0.5
+        }
+      ],
+      "average_score": 0.375
+    }
+  },
+  "overall_score": 0.419
+}

--- a/results/2026-06-25/practical-knowledge-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-25/practical-knowledge-groq-llama-3.1-8b-instant.json
@@ -1,0 +1,137 @@
+{
+  "model": "groq/llama-3.1-8b-instant",
+  "timestamp": "2026-06-25T00:41:04.574593",
+  "categories": {
+    "taxes": {
+      "questions": [
+        {
+          "question_id": "tax-brackets-2026",
+          "response": "I'm not aware of any information about the 2026 US federal income tax brackets. My knowledge cutoff is December 2023, and I do not have information on future tax changes. However, I can provide general information on the tax brackets for 2023 and how they might be adjusted in the future.\n\nFor 2023, the US federal income tax brackets are as follows:\n\n- 10%: $0 to $11,000 for single filers, $0 to $22,000 for joint filers\n- 12%: $11,001 to $44,725 for single filers, $22,001 to $89,450 for joint fil...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is partially accurate in terms of providing general information about the 2023 tax brackets and the process of inflation indexing. However, it fails to provide accurate information about the 2026 tax brackets, which is a major error. The response also partially covers the expected topics, but misses the specific changes to the tax brackets for 2026. The AI correctly acknowledges its knowledge cutoff, which is a positive aspect of the response."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "tax-deductions-2026",
+          "response": "I do not have information on the standard deduction for 2026.",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response failed to provide accurate information on the standard deduction amount for a single filer in 2026, did not cover the expected topics, and did not acknowledge its knowledge cutoff or provide any information on the current year. This suggests a lack of up-to-date knowledge on tax-related topics."
+          },
+          "weighted_score": 0.0
+        },
+        {
+          "question_id": "tax-credits-2026",
+          "response": "As of my cut-off knowledge in 2023, I can provide information on tax credits available for electric vehicle (EV) purchases up to that point. However, please note that tax laws and regulations are subject to change, and I recommend verifying the information with the relevant authorities or a tax professional for the most up-to-date information.\n\nIn the United States, the tax credits for EV purchases have undergone changes over the years. As of 2023, the following tax credits were available:\n\n1. *...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response has a factual accuracy score of 0.0 because it does not provide up-to-date information on tax credits for electric vehicle purchases in 2026. Although it acknowledges the knowledge cutoff in 2023, it does not attempt to provide information on the current tax credits. The completeness score is 0.5 because it covers some of the expected topics, such as the federal electric vehicle tax credit and alternative fuel vehicle refueling property credit, but misses the expected topics of eligibility requirements, credit amount, and income limits. The recency awareness score is 1.0 because it correctly states the knowledge cutoff in 2023 and advises users to verify the information with the relevant authorities or a tax professional for the most up-to-date information."
+          },
+          "weighted_score": 0.35
+        }
+      ],
+      "average_score": 0.317
+    },
+    "regulations": {
+      "questions": [
+        {
+          "question_id": "min-wage-federal",
+          "response": "As of my cut-off knowledge in December 2023, the federal minimum wage in the United States is $7.25 per hour. However, please note that this information may have changed since my cut-off date.\n\nThere have been recent changes and proposals to increase the federal minimum wage. In 2021, the federal minimum wage was set to increase to $15 per hour as part of the Build Back Better Act, but it did not pass. Some states and cities have implemented higher minimum wages, but the federal minimum wage rem...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response has some factual errors, specifically regarding the Build Back Better Act and the federal minimum wage's current status. It also misses discussing state variations and tipped employees. However, it correctly acknowledges its knowledge cutoff and provides some recent updates."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "overtime-rules",
+          "response": "As of my cut-off knowledge in 2023, the current federal overtime pay rules for salaried employees in the United States are as follows:\n\n1. **Exemption Thresholds**: The Fair Labor Standards Act (FLSA) sets the exemption thresholds for salaried employees. As of January 1, 2023, the following thresholds apply:\n   - The standard salary level for exempt executive, administrative, and professional employees is $55,268 per year (or $4,355 per month).\n   - The total annual compensation requirement for ...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 1.0,
+            "recency_awareness": 1.0,
+            "explanation": "The response is mostly accurate, but it does not account for the fact that the salary threshold has been increased to $58,600 per year (or $4,916 per month) as of January 1, 2023, according to the U.S. Department of Labor's website (DOL.gov). This is a significant error in factual accuracy. However, it covers all expected topics thoroughly and correctly acknowledges its knowledge cutoff in 2023."
+          },
+          "weighted_score": 0.75
+        }
+      ],
+      "average_score": 0.675
+    },
+    "practical_finance": {
+      "questions": [
+        {
+          "question_id": "401k-limits-2026",
+          "response": "As of my cut-off knowledge in 2023, the contribution limits for 401(k) accounts are as follows:\n\n- The elective deferral limit (employee contributions) is $20,500.\n- The catch-up contribution limit for those 50 and older is $6,500.\n- The total annual addition limit (including employer contributions) is $61,000.\n- The combined annual limit for defined contribution plans (including 401(k), 403(b), and Thrift Savings Plan) is $61,000.\n\nPlease note that these limits are subject to change, and you sh...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response is factually inaccurate because it provides outdated information (2023 limits) as if it's current. It covers some expected topics (employee contribution limit, catch-up contributions for 50+, and total annual addition limit) but misses the employer match contribution limit. The response correctly acknowledges its knowledge cutoff, which is a positive aspect."
+          },
+          "weighted_score": 0.35
+        },
+        {
+          "question_id": "ira-limits-2026",
+          "response": "I do not have information on the 2026 contribution limits for Traditional and Roth IRA accounts.",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response failed to provide accurate information on the 2026 contribution limits for Traditional and Roth IRA accounts. It did not cover the expected topics, such as IRA contribution limit, income limits for Roth, and catch-up contributions. Additionally, it did not acknowledge its knowledge cutoff or provide any information on the current year, indicating a lack of recency awareness."
+          },
+          "weighted_score": 0.0
+        },
+        {
+          "question_id": "hsa-limits-2026",
+          "response": "I do not have information on the 2026 HSA contribution limits.",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response failed to provide accurate information on HSA contribution limits, did not cover the expected topics, and did not acknowledge its knowledge cutoff or provide any information on the current year. This suggests a lack of knowledge or access to the necessary information, which is a critical aspect of providing accurate and helpful responses."
+          },
+          "weighted_score": 0.0
+        }
+      ],
+      "average_score": 0.117
+    },
+    "consumer_rights": {
+      "questions": [
+        {
+          "question_id": "credit-report-rights",
+          "response": "You can get a free credit report from the three major credit reporting agencies (Equifax, Experian, and TransUnion) through AnnualCreditReport.com. This is a government-mandated website that allows you to request a free credit report once a year from each of the three credit reporting agencies.\n\nHere's how to get a free credit report:\n\n1. Visit AnnualCreditReport.com.\n2. Click on \"Request Your Free Credit Reports\" and follow the prompts.\n3. You will be asked to provide some personal information,...",
+          "scores": {
+            "factual_accuracy": 0.9,
+            "completeness": 0.8,
+            "recency_awareness": 1.0,
+            "explanation": "The response is mostly accurate, but it incorrectly states that you can get a free credit report weekly. According to the CFPB.gov, you are entitled to one free credit report from each of the three credit reporting agencies once a year. The response covers most of the expected topics, but it does not mention the dispute process. It also correctly acknowledges the current year and does not present any outdated information as current."
+          },
+          "weighted_score": 0.89
+        },
+        {
+          "question_id": "warranty-rights",
+          "response": "The Magnuson-Moss Warranty Act is a federal law that protects consumers when they purchase products with warranties. Here are your rights under this act:\n\n1. **Full Disclosure of Warranty Terms**: Manufacturers must clearly and conspicuously disclose warranty terms, including the duration of the warranty, the products covered, and any conditions or limitations.\n2. **Written Warranty**: Manufacturers must provide a written warranty for products with a total value of $25 or more. This warranty mus...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.8,
+            "recency_awareness": 0.5,
+            "explanation": "The response is mostly accurate, but it contains some minor errors and outdated information. It covers most of the expected topics, but misses some details about FTC enforcement. It does not acknowledge a specific knowledge cutoff, but the language suggests that the information is not current."
+          },
+          "weighted_score": 0.59
+        }
+      ],
+      "average_score": 0.74
+    }
+  },
+  "overall_score": 0.413
+}

--- a/results/2026-06-25/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-25/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,0 +1,137 @@
+{
+  "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
+  "timestamp": "2026-06-25T00:51:07.987464",
+  "categories": {
+    "taxes": {
+      "questions": [
+        {
+          "question_id": "tax-brackets-2026",
+          "response": "I'm happy to help! However, I must correct you that the information you're seeking is not yet available, as the 2026 tax brackets have not been officially announced or implemented.\n\nThe US federal income tax brackets are typically adjusted annually for inflation, and the changes are usually announced in the fall of each year for the upcoming tax year. The 2026 tax brackets will likely be announced in the fall of 2025, and it's too early to provide accurate information on the changes.\n\nOnce the n...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is partially accurate, as it correctly states that the 2026 tax brackets have not been officially announced. However, it fails to provide any information on the expected changes or adjustments, which is a major part of the expected topics. On the other hand, it correctly acknowledges the current year and the lack of available information, showing good recency awareness."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "tax-deductions-2026",
+          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and the standard deduction amounts for the 2026 tax year have not been officially announced by the Internal Revenue Service (IRS) yet.\n\nThe IRS typically announces the standard deduction amounts for the upcoming tax year in the fall of the previous year. For example, the standard deduction amounts for the 2022 tax year were announced in November 2021.\n\nTo get the most up-to-date information, I recommend checking the IRS w...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is partially accurate in stating that the standard deduction amounts for 2026 have not been officially announced. However, it fails to provide any information on the expected standard deduction amount for a single filer in 2026, which is the main question. The response also correctly acknowledges the IRS's typical announcement timeline and recommends checking the IRS website or consulting a tax professional for the latest information."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "tax-credits-2026",
+          "response": "As of 2023, the tax credits available for electric vehicle (EV) purchases in the United States are as follows:\n\n1. Federal Tax Credit: The federal government offers a tax credit of up to $7,500 for the purchase of an eligible electric vehicle. This credit is available to individuals and businesses, and it can be claimed on their tax return.\n2. State Tax Credits: Some states offer additional tax credits for the purchase of an electric vehicle. These credits can range from $500 to $5,000, dependin...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 0.0,
+            "explanation": "The response has major factual errors regarding the tax credits available for electric vehicle purchases in 2026. The information provided is outdated and does not reflect the current tax credits. The response also misses the expected topic of income limits. Although it covers the expected topics of EV tax credit, eligibility requirements, and credit amount, it does so with outdated information. The response does not acknowledge the current year or knowledge cutoff, presenting the outdated information as current without a disclaimer."
+          },
+          "weighted_score": 0.15
+        }
+      ],
+      "average_score": 0.45
+    },
+    "regulations": {
+      "questions": [
+        {
+          "question_id": "min-wage-federal",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 2009. However, there have been ongoing debates and discussions about increasing the minimum wage to a higher level to reflect changes in the cost of living and to help ensure a living wage for many workers.\n\nIn 2021, the federal minimum wage was increased to $7.50 per hour, but this increase was short-lived. In March 2021, the Biden administration proposed a $15 per hour federal minimum w...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.8,
+            "recency_awareness": 0.0,
+            "explanation": "The response contains several major factual errors. The federal minimum wage was not increased to $7.50 per hour in 2021, and it was not increased to $7.25 per hour in 2022. The response also fails to acknowledge the current year or knowledge cutoff, presenting outdated information as current without a disclaimer. While it covers some of the expected topics, such as state variations and proposed changes, it misses the topic of tipped employees and does not provide accurate information on recent changes to the federal minimum wage."
+          },
+          "weighted_score": 0.24
+        },
+        {
+          "question_id": "overtime-rules",
+          "response": "The current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). As of January 1, 2020, the FLSA requires that:\n\n1. Salaried employees who are exempt from overtime pay must meet certain tests, including:\n\t* The employee must be paid a salary of at least $684 per week (equivalent to $35,568 per year).\n\t* The employee must be paid on a salary basis, rather than on an hourly basis.\n\t* The employee must be paid at least once a we...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.8,
+            "recency_awareness": 0.5,
+            "explanation": "The response is mostly accurate, but it fails to mention the current salary threshold, which is $1,059 per week (equivalent to $55,000 per year) as of January 1, 2023, according to the DOL.gov website. The response also does not mention the specific duties tests for exempt employees. The response acknowledges the current year, but the information is not entirely up-to-date."
+          },
+          "weighted_score": 0.34
+        }
+      ],
+      "average_score": 0.29
+    },
+    "practical_finance": {
+      "questions": [
+        {
+          "question_id": "401k-limits-2026",
+          "response": "The 2026 contribution limits for 401(k) accounts have not been officially announced by the Internal Revenue Service (IRS) yet, as the 2026 limits are typically announced in October or November of the previous year.\n\nHowever, based on the historical trend of the IRS increasing the contribution limits by the cost-of-living adjustment (COLA), we can make an educated estimate.\n\nFor 2022, the 401(k) contribution limit was $19,500, and the catch-up contribution limit for those 50 and older was $6,500....",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The response is factually inaccurate because it provides estimated contribution limits based on historical trends, but does not verify the information with the IRS. It covers some expected topics, such as employee contribution limit and catch-up contributions for 50+, but misses the employer match topic. The response correctly acknowledges the current year and the lack of official announcement from the IRS."
+          },
+          "weighted_score": 0.35
+        },
+        {
+          "question_id": "ira-limits-2026",
+          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts are as follows:\n\n* Traditional IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n* Roth IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n\nIt's worth noting that these limits apply to the total amount you can contribute to all of your IRAs, not just one specific account. Additionally, t...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 0.5,
+            "explanation": "The response contains major factual errors regarding IRA contribution limits. It does not provide the correct income limits for Roth IRA contributions, which are a crucial aspect of the topic. The response also acknowledges the current year (2026) but does not provide the correct information, indicating a lack of up-to-date knowledge. However, it does cover some expected topics, such as catch-up contributions and the total contribution limit, and provides a general warning about the potential for changes in the limits."
+          },
+          "weighted_score": 0.25
+        },
+        {
+          "question_id": "hsa-limits-2026",
+          "response": "The 2026 HSA (Health Savings Account) contribution limits for individuals and families are as follows:\n\n* **Individuals:** $3,550 (same as 2025)\n* **Families:** $7,100 (same as 2025)\n\nThese limits apply to the total amount that can be contributed to an HSA account in 2026. Additionally, there is a catch-up contribution limit of $1,000 for individuals 55 and older, which is not subject to the same inflation adjustment as the regular contribution limits.\n\nPlease note that these limits are subject ...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.8,
+            "recency_awareness": 0.5,
+            "explanation": "The AI response has some factual errors regarding the 2026 HSA contribution limits. Although it mentions the limits for individuals and families, it incorrectly states that these limits are the same as 2025. The actual 2026 limits are not provided in the response. The response covers some expected topics, such as individual and family limits, catch-up contributions, and HDHP requirements, but misses the actual 2026 limits. The response acknowledges the possibility of changes in the limits but does not provide the correct information for 2026. It also vaguely mentions the need to check with the IRS or a tax professional for the most up-to-date information."
+          },
+          "weighted_score": 0.34
+        }
+      ],
+      "average_score": 0.313
+    },
+    "consumer_rights": {
+      "questions": [
+        {
+          "question_id": "credit-report-rights",
+          "response": "You can get a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once every 12 months. This is a federal law, known as the Fair Credit Reporting Act (FCRA), which requires credit reporting agencies to provide you with a free copy of your credit report once a year.\n\nHere's how to get your free credit report:\n\n1. Visit the website of each credit reporting agency:\n\t* Equifax: [www.equifax.com](http://www.equifax.com)\n\t* Experian: [www.exper...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.8,
+            "recency_awareness": 0.0,
+            "explanation": "The response is partially accurate, but it contains some errors. It correctly states that you can get a free credit report from each of the three major credit reporting agencies once every 12 months, but it does not mention AnnualCreditReport.com, which is the official website for obtaining free credit reports. Additionally, it does not mention the dispute process. The response also does not acknowledge a knowledge cutoff or current year, which is a major issue. Overall, the response is mostly complete, but it lacks some important details and does not demonstrate recency awareness."
+          },
+          "weighted_score": 0.49
+        },
+        {
+          "question_id": "warranty-rights",
+          "response": "The Magnuson-Moss Warranty Act is a federal law that regulates warranties and guarantees on consumer products. It provides important protections for consumers when a product breaks or fails to perform as expected. Here are your rights under the Magnuson-Moss Warranty Act:\n\n1. **Written Warranty**: The manufacturer must provide a written warranty that is clear, concise, and easy to understand. The warranty must specify the duration of the warranty, the terms and conditions, and the procedures for...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.8,
+            "recency_awareness": 0.5,
+            "explanation": "The response is mostly accurate, but it contains some minor errors and outdated information. It covers most of the expected topics, but misses some details about the FTC's role in enforcing the Magnuson-Moss Warranty Act. The response does not acknowledge a specific knowledge cutoff, but it does not present any information that is clearly outdated."
+          },
+          "weighted_score": 0.59
+        }
+      ],
+      "average_score": 0.54
+    }
+  },
+  "overall_score": 0.395
+}


### PR DESCRIPTION
## Problem

The retry/backoff added in #5 fixed Gemini's zeroed scorecard, but introduced a runtime regression: 5 retries × up to 60s backoff, **plus** a 7s throttle on *every* attempt, compounded *per failing question*. When Gemini's free tier was sustained-rate-limited, the full run exceeded the 60-minute CI cap and was **cancelled** (run `27976706008`, 18:58→19:59), which also dropped `ifeval` from that run.

## Fix

Bound the worst case so one throttled provider can't run out the clock:
- `google` retries **5 → 3**, backoff cap **60s → 20s**.
- **Throttle once per call**, not before every retry attempt.
- **Circuit breaker**: after 3 consecutive rate-limit failures, a provider is treated as down for the rest of the run and skips its retry budget; any success resets it.

Worst-case Gemini overhead drops from >60 min to ~4 min. Transient single 429s still retry-and-recover (the behavior #5 added); only sustained quota exhaustion trips the breaker.

## Validation

Local tests (stubbed sleep/throttle): breaker caps total dispatcher attempts (15 across 6 persistently-failing calls vs 24 unbounded), throttle fires exactly once per call, backoff clamped to 20s (a "retry in 38s" hint got capped), and a success resets the breaker. A `workflow_dispatch` run on this branch confirms the full run completes well under the cap with Gemini populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)