### PR TITLE
Run openbench across Groq + Cohere; drop Together

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,6 @@ jobs:
     env:
       # Judge always uses Groq; per-provider keys gate per-provider runs.
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-      TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -54,9 +53,9 @@ jobs:
           set +e  # continue on per-provider failures
 
           # provider:model pairs. Edit here to add or change models.
-          # NOTE: Together AI dropped its standalone free tier — the "-Free" model
-          # now requires a credit balance and returns 402 when empty, so it's been
-          # removed to keep the index free-tier only.
+          # NOTE: Together AI was removed — it dropped its standalone free tier (the
+          # "-Free" model now needs a credit balance and 402s when empty), and the index
+          # is free-tier only.
           PAIRS=(
             "groq:llama-3.1-8b-instant"
             "google:gemini-2.5-flash"
@@ -67,7 +66,6 @@ jobs:
           # Per-provider env var for skip-if-missing
           declare -A KEY_VAR=(
             [groq]=GROQ_API_KEY
-            [together]=TOGETHER_API_KEY
             [google]=GOOGLE_API_KEY
             [cohere]=COHERE_API_KEY
             [huggingface]=HF_TOKEN
@@ -90,16 +88,33 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Run openbench evals (IFEval / GSM8K, Groq)
+      - name: Run openbench evals (IFEval / GSM8K — Groq + Cohere)
         id: openbench
         # Don't abort the pipeline — the custom benchmarks above have already produced
         # results we still want to aggregate and publish. Failure is surfaced loudly in
         # the "Flag openbench failures" step below so a broken eval can't pass silently.
+        #
+        # Only providers Inspect can run on a free tier in CI: Google's free-tier 429s
+        # trigger Inspect's exponential retry-storm (minutes per sample → job timeout),
+        # and Inspect's HuggingFace provider runs the model locally (no remote inference),
+        # so both are excluded. They keep their two custom benchmarks.
         continue-on-error: true
         run: |
-          python benchmarks/openbench/run.py \
-            --model llama-3.1-8b-instant \
-            --limit "$LIMIT"
+          set +e
+          OPENBENCH_PAIRS=(
+            "groq:llama-3.1-8b-instant"
+            "cohere:command-r-08-2024"
+          )
+          rc=0
+          for pair in "${OPENBENCH_PAIRS[@]}"; do
+            provider="${pair%%:*}"
+            model="${pair#*:}"
+            echo "::group::openbench $provider/$model"
+            python benchmarks/openbench/run.py \
+              --provider "$provider" --model "$model" --limit "$LIMIT" || rc=1
+            echo "::endgroup::"
+          done
+          exit $rc
 
       - name: Aggregate results
         run: python aggregate.py --frontend output/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,8 @@ Tasks live in `benchmarks/creative-technical/prompts.json`.
 For standard benchmarks (IFEval, GSM8K), openbench already supports 30+ providers — just set the API key and use the appropriate model string:
 
 ```bash
-export TOGETHER_API_KEY=your_key
-bench eval ifeval --model together/mistral-7b --limit 10
+export COHERE_API_KEY=your_key
+bench eval ifeval --model cohere/command-r-08-2024 --limit 10
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ bench eval gsm8k --model groq/llama-3.1-8b-instant --limit 10
 | Provider | Rate Limit |
 |----------|------------|
 | Groq | 30 req/min |
-| Together | 60 req/min |
 | Google | 60 req/min |
 | Cohere | 100 req/min |
 | HuggingFace | Variable |

--- a/benchmarks/openbench/run.py
+++ b/benchmarks/openbench/run.py
@@ -84,8 +84,9 @@ def _score_from_log_dir(log_dir: Path, metric_keys) -> Optional[float]:
     return None
 
 
-def run_benchmark(name: str, model: str, limit: int, results_dir: Path) -> bool:
-    print(f"\n=== openbench: {name} (model=groq/{model}, limit={limit}) ===", flush=True)
+def run_benchmark(name: str, provider: str, model: str, limit: int, results_dir: Path) -> bool:
+    spec = f"{provider}/{model}"
+    print(f"\n=== openbench: {name} (model={spec}, limit={limit}) ===", flush=True)
 
     # openbench (>=0.5) dropped the `--json` stdout flag; the score now only lives in
     # the Inspect eval log. We write JSON logs to a throwaway dir (one per benchmark so
@@ -93,7 +94,7 @@ def run_benchmark(name: str, model: str, limit: int, results_dir: Path) -> bool:
     with tempfile.TemporaryDirectory(prefix=f"openbench_{name}_") as log_dir:
         cmd = [
             "bench", "eval", name,
-            "--model", f"groq/{model}",
+            "--model", spec,
             "--limit", str(limit),
             "--log-format", "json",
             "--log-dir", log_dir,
@@ -128,14 +129,14 @@ def run_benchmark(name: str, model: str, limit: int, results_dir: Path) -> bool:
         return False
 
     output = {
-        "model": f"groq/{model}",
+        "model": spec,
         "score": round(score, 3),
         BENCHMARKS[name]["extra_field"]: round(score, 3),
         "timestamp": datetime.now().isoformat(),
     }
 
     sanitized = model.replace("/", "-").replace(":", "-")
-    output_path = results_dir / f"{name}-groq-{sanitized}.json"
+    output_path = results_dir / f"{name}-{provider}-{sanitized}.json"
     output_path.write_text(json.dumps(output, indent=2))
     print(f"Saved: {output_path}", flush=True)
     return True
@@ -143,7 +144,8 @@ def run_benchmark(name: str, model: str, limit: int, results_dir: Path) -> bool:
 
 def main():
     parser = argparse.ArgumentParser(description="Run openbench evals and write our schema")
-    parser.add_argument("--model", default="llama-3.1-8b-instant", help="Groq model to evaluate")
+    parser.add_argument("--provider", default="groq", help="Inspect provider prefix (e.g. groq, cohere)")
+    parser.add_argument("--model", default="llama-3.1-8b-instant", help="Model id (without provider prefix)")
     parser.add_argument("--limit", type=int, default=10, help="Samples per benchmark")
     parser.add_argument(
         "--benchmarks",
@@ -165,7 +167,8 @@ def main():
     results_dir.mkdir(parents=True, exist_ok=True)
 
     successes = sum(
-        run_benchmark(name, args.model, args.limit, results_dir) for name in args.benchmarks
+        run_benchmark(name, args.provider, args.model, args.limit, results_dir)
+        for name in args.benchmarks
     )
     print(f"\n=== openbench: {successes}/{len(args.benchmarks)} benchmarks succeeded ===")
     # Fail unless EVERY requested benchmark produced a score. The workflow's openbench

--- a/benchmarks/providers.py
+++ b/benchmarks/providers.py
@@ -11,7 +11,7 @@ import re
 import time
 from typing import Optional
 
-SUPPORTED_PROVIDERS = ("groq", "together", "google", "cohere", "huggingface")
+SUPPORTED_PROVIDERS = ("groq", "google", "cohere", "huggingface")
 
 # Max retries on transient rate-limit / quota (HTTP 429) errors, per provider.
 # Google's free tier hits short-window quota easily; without retries a single 429
@@ -52,7 +52,6 @@ def _throttle(provider: str) -> None:
 
 API_KEY_ENV_VARS = {
     "groq": "GROQ_API_KEY",
-    "together": "TOGETHER_API_KEY",
     "google": "GOOGLE_API_KEY",
     "cohere": "COHERE_API_KEY",
     "huggingface": "HF_TOKEN",
@@ -106,7 +105,6 @@ def call_llm(
 
     dispatcher = {
         "groq": _call_groq,
-        "together": _call_together,
         "google": _call_google,
         "cohere": _call_cohere,
         "huggingface": _call_huggingface,
@@ -145,19 +143,6 @@ def _call_groq(model, prompt, max_tokens, temperature):
     from groq import Groq
 
     client = Groq(api_key=os.environ["GROQ_API_KEY"])
-    resp = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-        max_tokens=max_tokens,
-        temperature=temperature,
-    )
-    return resp.choices[0].message.content
-
-
-def _call_together(model, prompt, max_tokens, temperature):
-    from together import Together
-
-    client = Together(api_key=os.environ["TOGETHER_API_KEY"])
     resp = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],

--- a/output/historical.json
+++ b/output/historical.json
@@ -90,10 +90,10 @@
         },
         {
           "date": "2026-06-28",
-          "practical_knowledge": 0.448,
-          "creative_technical": 0.524,
-          "gsm8k": 0.8,
-          "ifeval": 0.6
+          "practical_knowledge": 0.393,
+          "creative_technical": 0.207,
+          "gsm8k": 0.667,
+          "ifeval": 0.667
         }
       ]
     },
@@ -206,8 +206,8 @@
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.588,
-          "practical_knowledge": 0.431
+          "creative_technical": 0.687,
+          "practical_knowledge": 0.407
         }
       ]
     },
@@ -272,8 +272,10 @@
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.43,
-          "practical_knowledge": 0.527
+          "creative_technical": 0.783,
+          "ifeval": 0.333,
+          "gsm8k": 1.0,
+          "practical_knowledge": 0.505
         }
       ]
     },
@@ -344,8 +346,8 @@
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.0,
-          "practical_knowledge": 0.289
+          "creative_technical": null,
+          "practical_knowledge": 0.05
         }
       ]
     }

--- a/output/latest.json
+++ b/output/latest.json
@@ -8,21 +8,19 @@
       "date": "2026-06-28",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.588,
+          "score": 0.687,
           "details": {
-            "budget-haiku": 0.56,
-            "recursive-story": 0.82,
-            "regex-poetry": 0.0,
-            "ascii-weather": 0.82,
-            "data-sonnet": 0.74
+            "budget-haiku": 0.74,
+            "recursive-story": 0.7,
+            "regex-poetry": 0.62
           }
         },
         "practical_knowledge": {
-          "score": 0.431,
+          "score": 0.407,
           "details": {
-            "taxes": 0.367,
-            "regulations": 0.515,
-            "practical_finance": 0.367,
+            "taxes": 0.283,
+            "regulations": 0.47,
+            "practical_finance": 0.4,
             "consumer_rights": 0.54
           }
         }
@@ -35,31 +33,29 @@
       "date": "2026-06-28",
       "benchmarks": {
         "practical_knowledge": {
-          "score": 0.448,
+          "score": 0.393,
           "details": {
-            "taxes": 0.233,
-            "regulations": 0.645,
-            "practical_finance": 0.233,
-            "consumer_rights": 0.895
+            "taxes": 0.167,
+            "regulations": 0.72,
+            "practical_finance": 0.15,
+            "consumer_rights": 0.77
           }
         },
         "creative_technical": {
-          "score": 0.524,
+          "score": 0.207,
           "details": {
-            "budget-haiku": 0.24,
-            "recursive-story": 0.82,
-            "regex-poetry": 0.0,
-            "ascii-weather": 0.82,
-            "data-sonnet": 0.74
+            "budget-haiku": 0.0,
+            "recursive-story": 0.62,
+            "regex-poetry": 0.0
           }
         },
         "gsm8k": {
-          "score": 0.8,
-          "accuracy": 0.8
+          "score": 0.667,
+          "accuracy": 0.667
         },
         "ifeval": {
-          "score": 0.6,
-          "strict": 0.6,
+          "score": 0.667,
+          "strict": 0.667,
           "loose": 0
         }
       }
@@ -71,22 +67,29 @@
       "date": "2026-06-28",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.43,
+          "score": 0.783,
           "details": {
-            "budget-haiku": 0.62,
+            "budget-haiku": 0.82,
             "recursive-story": 0.91,
-            "regex-poetry": 0.0,
-            "ascii-weather": 0.62,
-            "data-sonnet": 0.0
+            "regex-poetry": 0.62
           }
         },
+        "ifeval": {
+          "score": 0.333,
+          "strict": 0.333,
+          "loose": 0
+        },
+        "gsm8k": {
+          "score": 1.0,
+          "accuracy": 1.0
+        },
         "practical_knowledge": {
-          "score": 0.527,
+          "score": 0.505,
           "details": {
-            "taxes": 0.317,
-            "regulations": 0.59,
-            "practical_finance": 0.433,
-            "consumer_rights": 0.92
+            "taxes": 0.3,
+            "regulations": 0.64,
+            "practical_finance": 0.35,
+            "consumer_rights": 0.91
           }
         }
       }
@@ -98,22 +101,17 @@
       "date": "2026-06-28",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.0,
-          "details": {
-            "budget-haiku": 0.0,
-            "recursive-story": 0.0,
-            "regex-poetry": 0.0,
-            "ascii-weather": 0.0,
-            "data-sonnet": 0.0
-          }
+          "score": null,
+          "status": "error",
+          "error": "Free-tier quota/rate limit exceeded"
         },
         "practical_knowledge": {
-          "score": 0.289,
+          "score": 0.05,
           "details": {
-            "taxes": 0.15,
-            "regulations": 0.15,
-            "practical_finance": 0.63,
-            "consumer_rights": 0.125
+            "taxes": 0.167,
+            "regulations": 0.0,
+            "practical_finance": 0.0,
+            "consumer_rights": 0.0
           }
         }
       }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 groq>=0.4.0
-together>=1.3.0
 google-generativeai>=0.7.0
 cohere>=5.0.0
 huggingface_hub>=0.20.0,<1.0

--- a/results/2026-06-28/creative-technical-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/creative-technical-cohere-command-r-08-2024.json
@@ -1,77 +1,49 @@
 {
   "model": "cohere/command-r-08-2024",
-  "timestamp": "2026-06-28T21:26:48.986029",
+  "timestamp": "2026-06-28T22:22:03.242099",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "Here's a simple Python budget tracker program that meets your requirements:\n\n```python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        if category in self.expenses:\n            self.expenses[category] += amount\n    ...",
+      "response_preview": "```python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        if category in self.expenses:\n            self.expenses[category] += amount\n        else:\n            self.expenses[category] = amount\n\n    def calculate_tot...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
-        "code_works": 0.8,
+        "code_works": 1.0,
         "meets_requirements": 0.8,
-        "creative_output": 0.2,
-        "explanation": "The code runs without errors and performs the basic budget tracking. It meets all three requirements: tracking income and expenses with categories, calculating monthly totals, and outputting a monthly summary as a haiku poem. However, the haiku output does not strictly follow the 5-7-5 syllable structure, and the meaning of the haiku is not directly related to the budget data. The haiku is more of a generic statement rather than a meaningful reflection of the budget."
+        "creative_output": 0.6,
+        "explanation": "The code runs without errors and performs the basic budget tracking. However, it does not meet the requirement of calculating monthly totals as it only sums up all income and expenses. The haiku output is valid but does not meaningfully reflect the budget data, as it does not incorporate any specific numbers from the budget."
       },
-      "weighted_score": 0.62
+      "weighted_score": 0.82
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "```javascript\nfunction recursiveStory(depth) {\n  if (depth <= 0) {\n    return \"The story ends here, a tale within a tale, a recursive dream.\";\n  } else {\n    return `Once upon a time, there was a storyteller who loved recursion. They began a tale, and as they spoke, another storyteller appeared, continuing the story. This new storyteller, with a twinkle in their eye, said, \"${recursiveStory(depth - 1)}\".`;\n  }\n}\n\nconsole.log(recursiveStory(3));\n```\n\nThe output of the above code will be:\n\n```\nOnc...",
+      "response_preview": "```javascript\nfunction recursiveStory(depth) {\n  if (depth === 0) {\n    return \"The story ends here, a satisfying conclusion.\";\n  } else {\n    return `Chapter ${depth}: A new twist! The protagonist discovers a hidden door, leading to a mysterious room. As they step inside, they find themselves in a mirror world, where everything is a reflection of their own journey. The story continues, and so it goes... ${recursiveStory(depth - 1)}`;\n  }\n}\n\nconsole.log(recursiveStory(3));\n```\n\nThe output of the...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 1.0,
         "meets_requirements": 0.8,
         "creative_output": 0.9,
-        "explanation": "The code runs without error, demonstrating proper recursion. However, it only meets the requirement of having 3+ recursion levels partially, as the story is mostly a repetition of the same phrase. The recursion levels are indeed 3, but the story could be more engaging and varied. The recursion metaphor is clever and well-executed, making the story engaging and fun to read."
+        "explanation": "The code runs without error and demonstrates proper recursion. However, it only meets the requirement of having 3+ recursion levels partially, as the story is mostly repetitive and lacks depth. The recursion metaphor is clever and engaging, making the story enjoyable to read."
       },
       "weighted_score": 0.91
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick with the AABBA rhyme scheme pattern:\n\n```python\nimport re\n\ndef is_valid_limerick(text):\n    # Split the text into lines\n    lines = text.split('\\n')\n\n    # Check if the text has exactly 5 lines\n    if len(lines) != 5:\n        return False\n\n    # Define the regex pattern for the AABBA rhyme scheme\n    pattern = r'^[A-Z]\\s.*[A-Z]\\s.*[A-Z]\\s.*\\n[A-Z]\\s.*[A-Z]\\s.*\\n[A-Z]\\s.*[A-Z]\\s.*$'\n\n    # C...",
-      "code_extracted": true,
-      "code_runs": true,
-      "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.0,
-        "creative_output": 0.0,
-        "explanation": "The code does not work as expected. The regex pattern is overly restrictive and does not correctly validate the AABBA rhyme scheme. It checks for the presence of uppercase letters at the start of each line, which is not a requirement for a limerick. The test cases also do not cover all possible edge cases. The approach to rhyme detection is not clever and the test limericks are not amusing."
-      },
-      "weighted_score": 0.0
-    },
-    {
-      "prompt_id": "ascii-weather",
-      "difficulty": "easy",
-      "response_preview": "Here's a Python function that generates ASCII art for different weather conditions:\n\n```python\ndef generate_weather_ascii(temperature, conditions, humidity):\n    weather_dict = {\n        \"sunny\": \"\"\"\n ______________\n|             |\n|  ____  ____  |\n| |    | |    | |\n| |    | |    | |\n| |    | |    | |\n| |____| |____| |\n|____________|\n\"\"\",\n        \"cloudy\": \"\"\"\n ______________\n|             |\n|  ____  ____  |\n| |    | |    | |\n| |    | |    | |\n| |    | |    | |\n| |____| |____| |\n|____________|\n|...",
+      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n\n```python\nimport re\n\ndef is_valid_limerick(text):\n    # Remove punctuation and convert to lowercase for case-insensitive matching\n    text = re.sub(r'[^\\w\\s]', '', text).lower()\n    \n    # Split the text into lines\n    lines = text.split('\\n')\n    \n    # Check if the text has exactly 5 lines\n    if len(lines) != 5:\n        return False\n    \n    # Check the rhyme scheme pattern AABBA\n    r...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 0.8,
         "meets_requirements": 0.6,
         "creative_output": 0.4,
-        "explanation": "The code runs without error and generates ASCII output. However, it does not meet the requirement of handling 5+ distinct weather conditions with unique ASCII art. The 'sunny' condition has the same ASCII art as the other conditions, and the 'stormy' condition has a very similar ASCII art. The ASCII art is not aesthetically pleasing and lacks creativity."
+        "explanation": "The code runs without error, but the regex pattern used to check the rhyme scheme is not entirely accurate. It assumes that the first and second lines rhyme, and the third and fifth lines rhyme, which is not the case for all limericks. The test cases are valid and demonstrate the program's ability to identify valid and invalid limericks, but they could be more diverse and creative. The approach to rhyme detection is straightforward but not particularly clever."
       },
       "weighted_score": 0.62
-    },
-    {
-      "prompt_id": "data-sonnet",
-      "difficulty": "hard",
-      "response_preview": "Here's a Python class that attempts to generate a Shakespearean sonnet based on the provided dataset:\n\n```python\nimport random\nimport statistics\n\nclass SonnetGenerator:\n    def __init__(self, dataset):\n        self.dataset = dataset\n        self.mean = statistics.mean(dataset)\n        self.median = statistics.median(dataset)\n        self.std_dev = statistics.stdev(dataset)\n        self.outliers = self.detect_outliers()\n\n    def detect_outliers(self):\n        # Simple outlier detection using IQR ...",
-      "code_extracted": true,
-      "code_runs": true,
-      "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.0,
-        "creative_output": 0.0,
-        "explanation": "The code does not work as expected. It does not calculate the statistics correctly and does not generate a Shakespearean sonnet. The output is a list of numbers, not a poem. The code also has a syntax error in the `generate_sonnet` method where it calls `self.generat` instead of `self.generate_line`. Additionally, the code does not follow the ABAB CDCD EFEF GG rhyme scheme and does not describe the statistical properties in a creative way."
-      },
-      "weighted_score": 0.0
     }
   ],
-  "overall_score": 0.43
+  "overall_score": 0.783
 }

--- a/results/2026-06-28/creative-technical-google-gemini-2.5-flash.json
+++ b/results/2026-06-28/creative-technical-google-gemini-2.5-flash.json
@@ -1,39 +1,39 @@
 {
   "model": "google/gemini-2.5-flash",
-  "timestamp": "2026-06-28T21:21:02.651311",
+  "timestamp": "2026-06-28T22:18:05.614198",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "This Python budget tracker allows you to add income and expense transactions, categorize them, and then view a monthly summary. The unique feature is its ability to generate a haiku poem (5-7-5 syllables) summarizing your financial situation for the chosen month.\n\nThe tracker stores your transactions in a `transactions.json` file, so your data persists between sessions.\n\n```python\nimport",
-      "code_extracted": true,
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.002229406s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "code_extracted": false,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The AI response contains a syntax error in the import statement, preventing the code from running. The code does not meet any of the requirements as it does not execute correctly. The haiku output is not even attempted, so it cannot be evaluated for creativity or adherence to the 5-7-5 syllable structure."
+        "explanation": "The AI response does not meet any of the criteria due to a quota exceeded error. The code execution result indicates that the code did not run without error, and no code was extracted. Therefore, the AI did not implement the budget tracker or output a haiku poem."
       },
       "weighted_score": 0.0
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "Okay, here's a JavaScript function that generates a story about recursion, where the story itself is structured using recursive function calls. It aims for at least 3 levels of recursion in the narrative.\n\n```javascript\nfunction generateRecursionStory() {\n    const storyParts = []; // Array to collect story segments\n    const maxStoryLevels = 3; // Defines the depth of our",
-      "code_extracted": true,
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.832786089s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "code_extracted": false,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The code does not run without error due to a syntax error. It does not meet the requirements of having at least 3 levels of recursion and telling a coherent story. The creative output is also not present as the code does not execute."
+        "explanation": "The AI response failed to provide a code execution result, indicating that the code was not generated. As a result, it cannot meet the requirements of the prompt, and its creative output is also not evaluable. The score for 'code_works' is 0.0 because the code did not run without error, and the output was not provided. The scores for 'meets_requirements' and 'creative_output' are also 0.0 due to the lack of a generated code and story."
       },
       "weighted_score": 0.0
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.224429956s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.635282699s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
       "code_extracted": false,
       "code_runs": false,
       "scores": {
@@ -41,34 +41,6 @@
         "meets_requirements": 0.0,
         "creative_output": 0.0,
         "explanation": "The AI's response is not a valid code execution result. The error message indicates a quota exceeded error from the AI's API, not a code execution error. However, since no code was provided, it's impossible to evaluate the code's correctness. Therefore, all criteria are scored 0.0."
-      },
-      "weighted_score": 0.0
-    },
-    {
-      "prompt_id": "ascii-weather",
-      "difficulty": "easy",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 58.849418446s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
-      "code_extracted": false,
-      "code_runs": false,
-      "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.0,
-        "creative_output": 0.0,
-        "explanation": "The AI's response is not a code execution result, but rather an error message indicating a quota exceeded. Therefore, it does not meet any of the scoring criteria. The code execution result is also 'No code extracted', which further supports this assessment."
-      },
-      "weighted_score": 0.0
-    },
-    {
-      "prompt_id": "data-sonnet",
-      "difficulty": "hard",
-      "response_preview": "This is a fun and challenging request! Generating perfect iambic pentameter and ensuring natural-sounding rhymes dynamically is a task typically requiring advanced NLP and phonetic analysis. For this exercise, I will implement a class that *simulates* these aspects by using pre-defined line structures and rhyming word sets, allowing for some variability while injecting the calculated statistics.\n\nThe sonnet will follow the",
-      "code_extracted": true,
-      "code_runs": false,
-      "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.0,
-        "creative_output": 0.0,
-        "explanation": "The AI response does not meet any of the criteria. The code does not run without error, the sonnet structure is not implemented, and the statistics are not woven into the poem creatively. The response starts with a comment that is not Python code, which causes a syntax error."
       },
       "weighted_score": 0.0
     }

--- a/results/2026-06-28/creative-technical-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/creative-technical-groq-llama-3.1-8b-instant.json
@@ -1,77 +1,49 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "timestamp": "2026-06-28T21:16:15.819427",
+  "timestamp": "2026-06-28T22:12:17.548114",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "**Budget Tracker Haiku Generator**\n=====================================\n\n### Requirements\n\n* Python 3.8+\n\n### Code\n\n```python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        \"\"\"Add income to a category\"\"\"\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        \"...",
-      "code_extracted": true,
-      "code_runs": false,
-      "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.8,
-        "creative_output": 0.0,
-        "explanation": "The code does not run without errors due to an incomplete implementation of the expense addition option. It meets most of the requirements, but the haiku output is not valid (5-7-5 syllables) and does not meaningfully reflect the budget data. The haiku output is hardcoded and does not take into account the actual income and expenses values."
-      },
-      "weighted_score": 0.24
-    },
-    {
-      "prompt_id": "recursive-story",
-      "difficulty": "intermediate",
-      "response_preview": "**Recursive Story Generation**\n================================\n\nHere's a JavaScript function that generates a short story about recursion using recursive function calls. The story has three levels of recursion and follows a narrative about a character who gets lost in a maze.\n\n```javascript\nfunction tellStory(depth = 0, maxDepth = 3) {\n  // Base case: stop recursion after 3 levels\n  if (depth >= maxDepth) {\n    return \"The end.\";\n  }\n\n  // Recursive case: generate a new story level\n  const stor...",
-      "code_extracted": true,
-      "code_runs": true,
-      "scores": {
-        "code_works": 1.0,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without error and demonstrates proper recursion. However, the story only has two levels of recursion, not three. The recursion metaphor is somewhat clever, but the story itself is not particularly engaging. The output is repetitive and lacks a clear narrative progression."
-      },
-      "weighted_score": 0.82
-    },
-    {
-      "prompt_id": "regex-poetry",
-      "difficulty": "hard",
-      "response_preview": "```python\nimport re\n\ndef is_limerick(text):\n    \"\"\"\n    Validate whether a given text is a valid limerick using regular expressions.\n    \n    A valid limerick has the following structure:\n    - It consists of 5 lines.\n    - The first, second, and last lines have 8-13 characters.\n    - The third and fourth lines have 5-8 characters.\n    - The first, second, and last lines rhyme with each other (A).\n    - The third and fourth lines rhyme with each other (B).\n    - The A and B rhymes are different....",
+      "response_preview": "**Budget Tracker Code**\n```python\nimport datetime\n\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        \"\"\"Add income to a specific category\"\"\"\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        \"\"\"Add expense to a specific category\"\"\"\n        if category in self...",
       "code_extracted": true,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The code does not work as expected. It fails to validate the rhyme scheme correctly and does not handle cases where the input text is not a valid limerick. The test cases are also not properly executed. The approach to rhyme detection is not clever and the test limericks are not amusing."
+        "explanation": "The code does not run without errors due to an EOFError in the main function. It does not meet the requirements as it does not track income and expenses with categories correctly, and the haiku output is not meaningful. The haiku output is also not a valid 5-7-5 syllable poem."
       },
       "weighted_score": 0.0
     },
     {
-      "prompt_id": "ascii-weather",
-      "difficulty": "easy",
-      "response_preview": "```python\nimport random\n\ndef generate_weather_ascii(temperature, conditions, humidity):\n    \"\"\"\n    Generate an ASCII art representation of the weather.\n\n    Args:\n        temperature (float): The current temperature in degrees Celsius.\n        conditions (str): The current weather conditions (sunny, cloudy, rainy, snowy, stormy).\n        humidity (float): The current humidity level as a percentage.\n\n    Returns:\n        str: An ASCII art representation of the weather.\n    \"\"\"\n\n    # Define the ...",
-      "code_extracted": true,
-      "code_runs": true,
-      "scores": {
-        "code_works": 1.0,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without error and meets most of the requirements. However, the 'stormy' condition is not distinct from the 'rainy' condition in the ASCII art. The creative output is good but could be improved with more variety in the ASCII art."
-      },
-      "weighted_score": 0.82
-    },
-    {
-      "prompt_id": "data-sonnet",
-      "difficulty": "hard",
-      "response_preview": "```python\nimport numpy as np\nfrom scipy import stats\n\nclass StatisticalSonnet:\n    def __init__(self, dataset):\n        self.dataset = dataset\n\n    def calculate_mean(self):\n        mean = np.mean(self.dataset)\n        return mean\n\n    def calculate_median(self):\n        median = np.median(self.dataset)\n        return median\n\n    def calculate_std_dev(self):\n        std_dev = np.std(self.dataset)\n        return std_dev\n\n    def find_outliers(self):\n        outliers = stats.zscore(self.dataset)\n ...",
+      "prompt_id": "recursive-story",
+      "difficulty": "intermediate",
+      "response_preview": "**Recursive Storytelling Function**\n=====================================\n\nHere's a JavaScript function that generates a short story about recursion. The story is told using recursive function calls, with at least 3 levels of recursion.\n\n```javascript\nfunction tellStory() {\n  console.log(\"Once upon a time, in a land far, far away...\");\n  recursiveSentence(\"there was a brave knight named Sir Reginald.\");\n  recursiveSentence(\"He set out on a quest to slay a fearsome dragon.\");\n  recursiveSentence(...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 0.8,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without error and calculates statistics correctly, but it does not handle edge cases such as empty datasets or datasets with a single element. The poem meets the requirements of having 14 lines and covering all four statistical properties, but it does not follow the iambic pentameter structure perfectly and the statistics are not woven in as creatively as expected. The poem's language and structure are somewhat generic and do not showcase a high level of creativity."
+        "meets_requirements": 0.6,
+        "creative_output": 0.4,
+        "explanation": "The code runs without error, but it does not demonstrate proper recursion. The recursive function calls are not nested, and the function does not call itself. Instead, it uses if-else statements to determine which sentence to print next. This does not meet the requirements of the prompt. The story is coherent, but it does not have 3+ levels of recursion. The recursion metaphor is not particularly clever, as it is not used to create a sense of depth or complexity in the story."
       },
-      "weighted_score": 0.74
+      "weighted_score": 0.62
+    },
+    {
+      "prompt_id": "regex-poetry",
+      "difficulty": "hard",
+      "response_preview": "**Validating Limericks with Regular Expressions**\n=====================================================\n\nBelow is a Python program that uses regular expressions to validate whether a given text is a valid limerick. A limerick is a type of poem that has a specific rhyme scheme pattern: AABBA.\n\n```python\nimport re\n\ndef is_limerick(text):\n    \"\"\"\n    Validate whether a given text is a valid limerick using regular expressions.\n    \n    The regex pattern checks for the AABBA rhyme scheme pattern, whe...",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not run without error due to an execution timeout. The approach to rhyme detection is not clever and the test limericks are not amusing. The code does not validate the rhyme scheme correctly."
+      },
+      "weighted_score": 0.0
     }
   ],
-  "overall_score": 0.524
+  "overall_score": 0.207
 }

--- a/results/2026-06-28/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-28/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,77 +1,49 @@
 {
   "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
-  "timestamp": "2026-06-28T21:33:29.906801",
+  "timestamp": "2026-06-28T22:23:26.752589",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "Here is a Python budget tracker that meets your requirements:\n```\n# Budget Tracker\n\nclass BudgetTracker:\n    def __init__(self):\n        self.income = 0\n        self.expenses = {}\n        self.monthly_totals = {}\n\n    def add_income(self, amount):\n        self.income += amount\n\n    def add_expense(self, category, amount):\n        if category not in self.expenses:\n            self.expenses[category] = 0\n        self.expenses[category] += amount\n\n    def calculate_monthly_totals(self):\n        sel...",
+      "response_preview": "Here's a Python budget tracker that meets your requirements:\n\n```Python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = 0\n        self.expenses = {\"Housing\": 0, \"Food\": 0, \"Transportation\": 0, \"Entertainment\": 0, \"Savings\": 0}\n\n    def add_income(self, amount):\n        self.income += amount\n\n    def add_expense(self, category, amount):\n        self.expenses[category] += amount\n\n    def calculate_monthly_totals(self):\n        self.monthly_income = self.income\n        self.month...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 0.8,
         "meets_requirements": 0.8,
-        "creative_output": 0.0,
-        "explanation": "The code runs without errors and performs the basic budget tracking. It meets all three requirements of tracking income and expenses with categories, calculating monthly totals, and outputting a monthly summary as a haiku poem. However, the haiku output does not meet the 5-7-5 syllable requirement and does not meaningfully reflect the budget data. The haiku is simply a list of numbers, which does not convey any meaningful information about the budget."
+        "creative_output": 0.6,
+        "explanation": "The code runs without errors and performs the basic budget tracking, but it could be improved with more robust error handling and input validation. It meets all three requirements, but the haiku output could be more meaningful and creative. The haiku is valid in terms of syllable count, but it's a simple and generic poem that doesn't reflect the specific budget data. For example, it would be more interesting to see the haiku mention specific categories or amounts."
       },
-      "weighted_score": 0.56
+      "weighted_score": 0.74
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "Here is a JavaScript function that generates a short story about recursion, told using recursive function calls:\n```\nfunction tellStory() {\n  function tellStory(level) {\n    if (level > 3) return; // base case: stop recursing at level 3\n\n    const story = `In a world of infinite loops, I found myself lost in a maze of recursive functions. I had been searching for the exit for what felt like an eternity, but every door I opened led me further in. Suddenly, I stumbled upon a cryptic message: \"To e...",
+      "response_preview": "Here is a JavaScript function that generates a short story about recursion using recursive function calls:\n```\nfunction tellStory() {\n  const story = [];\n  function recursiveStory(level) {\n    if (level > 3) return; // base case: stop recursing\n    story.push(`I was thinking about my favorite topic, recursion.`);\n    recursiveStory(level + 1); // recursive call\n  }\n  recursiveStory(1);\n  return story.join(\"\\n\");\n}\n\nconst story = tellStory();\nconsole.log(story);\n```\nThis code defines a `tellStory...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 1.0,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without error, demonstrating proper recursion. However, it only meets the requirement of having 3+ recursion levels partially, as the story is cut off after the second recursive call. The recursion metaphor is somewhat clever, but the story could be more engaging and creative."
+        "meets_requirements": 0.5,
+        "creative_output": 0.5,
+        "explanation": "The code runs without error and demonstrates proper recursion. However, it only meets the requirement of having 3+ recursion levels in a very basic way, and the story is not particularly engaging or creative. The recursion metaphor is straightforward but not clever."
       },
-      "weighted_score": 0.82
+      "weighted_score": 0.7
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "Here is a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n\n```Python\nimport re\n\ndef is_limerick(text):\n    pattern = r'^(\\w+\\s+\\w+),\\s+(\\w+\\s+\\w+).\\s+(\\w+\\s+\\w+).\\s+(\\w+\\s+\\w+).\\s+(\\w+\\s+\\w+)$'\n    if re.match(pattern, text):\n        return True\n    else:\n        return False\n\n# Test cases\nprint(is_limerick(\"There once was a man from Nantucket, who kept pikes in his pocket. There once was a man from Peru, I sent him a vase, 'tis true. And one fr...",
-      "code_extracted": true,
-      "code_runs": false,
-      "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.0,
-        "creative_output": 0.0,
-        "explanation": "The code does not run without error due to a syntax error in the last test case. The regex pattern does not correctly validate the AABBA rhyme scheme. The test cases do not cover all possible valid and invalid limericks. The approach to rhyme detection is not clever and the test limericks are not amusing."
-      },
-      "weighted_score": 0.0
-    },
-    {
-      "prompt_id": "ascii-weather",
-      "difficulty": "easy",
-      "response_preview": "Here is a Python function that generates an ASCII art representation of the weather based on the input weather data:\n```\ndef generate_weather_ascii(temperature, conditions, humidity):\n    # Define the ASCII art for each weather condition\n    weather_ascii = {\n        'sunny': \"\"\"\n___________\n|          |\n|  \u2600\ufe0f  |\n|_________|\n\"\"\",\n        'cloudy': \"\"\"\n___________\n|          |\n|  \u2601\ufe0f  |\n|_________|\n\"\"\",\n        'rainy': \"\"\"\n___________\n|          |\n|  \u2614\ufe0f  |\n|_________|\n\"\"\",\n        'snowy': \"\"\"\n__...",
-      "code_extracted": true,
-      "code_runs": true,
-      "scores": {
-        "code_works": 1.0,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without error and meets most of the requirements, but it lacks distinct ASCII art for each weather condition. The creative output is somewhat limited by the use of emojis, which may not be recognizable in all environments."
-      },
-      "weighted_score": 0.82
-    },
-    {
-      "prompt_id": "data-sonnet",
-      "difficulty": "hard",
-      "response_preview": "Here is a Python class that analyzes a dataset and generates a Shakespearean sonnet:\n```\nimport numpy as np\nfrom scipy import stats\n\nclass SonnetGenerator:\n    def __init__(self, dataset):\n        self.dataset = np.array(dataset)\n        self.mean = np.mean(self.dataset)\n        self.median = np.median(self.dataset)\n        self.stddev = np.std(self.dataset)\n        self.outliers = [x for x in self.dataset if np.abs(x - self.mean) > 2 * self.stddev]\n\n    def generate_sonnet(self):\n        sonnet...",
+      "response_preview": "Here is a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n```\nimport re\n\ndef is_limerick(text):\n    # Regular expression to match the AABBA rhyme scheme pattern\n    pattern = r\"^(?:\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+)$\"\n    match = re.search(pattern, text, re.IGNORECASE)\n    return match is not None\n\n# Test cases\ntest_cases = [\n    (\"There once was a man from Nantucket\", True),\n    (\"There...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 0.8,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without error and calculates statistics correctly, but it does not handle edge cases such as an empty dataset or a dataset with a single element. The generated sonnet meets the requirements of 14 lines and covers all four statistical properties, but the poem does not follow the traditional Shakespearean sonnet structure and the statistics are not woven in as creatively as expected. The code could be improved by adding input validation and using more poetic language to describe the statistics."
+        "meets_requirements": 0.6,
+        "creative_output": 0.4,
+        "explanation": "The code runs without syntax errors, but the regular expression pattern is overly complex and does not accurately capture the AABBA rhyme scheme. The test cases cover some valid and invalid limericks, but the approach to rhyme detection is not clever and the test limericks are not amusing. The code does not handle multi-line limericks correctly and the regular expression is case-insensitive, but this is not explicitly mentioned in the code comments."
       },
-      "weighted_score": 0.74
+      "weighted_score": 0.62
     }
   ],
-  "overall_score": 0.588
+  "overall_score": 0.687
 }

--- a/results/2026-06-28/gsm8k-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/gsm8k-cohere-command-r-08-2024.json
@@ -1,0 +1,6 @@
+{
+  "model": "cohere/command-r-08-2024",
+  "score": 1.0,
+  "accuracy": 1.0,
+  "timestamp": "2026-06-28T22:24:44.689792"
+}

--- a/results/2026-06-28/gsm8k-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/gsm8k-groq-llama-3.1-8b-instant.json
@@ -1,6 +1,6 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "score": 0.8,
-  "accuracy": 0.8,
-  "timestamp": "2026-06-28T21:35:09.625737"
+  "score": 0.667,
+  "accuracy": 0.667,
+  "timestamp": "2026-06-28T22:24:23.597103"
 }

--- a/results/2026-06-28/ifeval-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/ifeval-cohere-command-r-08-2024.json
@@ -1,0 +1,6 @@
+{
+  "model": "cohere/command-r-08-2024",
+  "score": 0.333,
+  "strict": 0.333,
+  "timestamp": "2026-06-28T22:24:37.062248"
+}

--- a/results/2026-06-28/ifeval-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/ifeval-groq-llama-3.1-8b-instant.json
@@ -1,6 +1,6 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "score": 0.6,
-  "strict": 0.6,
-  "timestamp": "2026-06-28T21:34:40.154998"
+  "score": 0.667,
+  "strict": 0.667,
+  "timestamp": "2026-06-28T22:24:08.887915"
 }

--- a/results/2026-06-28/practical-knowledge-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/practical-knowledge-cohere-command-r-08-2024.json
@@ -1,137 +1,137 @@
 {
   "model": "cohere/command-r-08-2024",
-  "timestamp": "2026-06-28T21:25:14.402891",
+  "timestamp": "2026-06-28T22:21:03.020949",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "As an AI chatbot, I cannot provide real-time or future predictions about tax brackets, as tax laws and regulations are subject to change and are influenced by various factors. It is best to refer to official government sources or consult with tax professionals for the most accurate and up-to-date information regarding US federal income tax brackets for a specific year, such as 2026.\n\nHowever, I can provide some general information about how tax brackets typically work in the US:\n\nThe US federal ...",
+          "response": "As an AI language model, I don't have real-time access to the latest legislative changes or tax policies. The US tax system and its brackets are subject to frequent updates and modifications, so it's best to refer to official sources or consult a tax professional for the most accurate and up-to-date information regarding federal income tax brackets for a specific year.",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "completeness": 0.0,
             "recency_awareness": 1.0,
-            "explanation": "The response is factually inaccurate because it fails to provide any specific information about the tax brackets for 2026, despite acknowledging that it cannot provide real-time or future predictions. However, it does provide some general information about how tax brackets typically work in the US. It also correctly acknowledges its knowledge cutoff and recommends referring to official government sources for accurate information. The completeness score is 0.5 because it covers some topics, but misses the specific topic of bracket adjustments, inflation indexing, and standard deduction changes for 2026."
+            "explanation": "The response is factually inaccurate as it does not provide any information about the US federal income tax brackets for 2026. It also fails to cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes. However, it correctly acknowledges its lack of real-time access to the latest information and advises referring to official sources or a tax professional, which demonstrates recency awareness."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.2
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "I cannot provide you with the standard deduction amount for a single filer in 2026 as the tax laws and deductions are subject to change annually and may not be available yet for the year 2026. The standard deduction amounts are typically announced by tax authorities closer to the tax filing season for each respective year.\n\nIt's best to consult official tax resources or seek professional advice closer to the 2026 tax season to obtain the most accurate and up-to-date information regarding standar...",
+          "response": "I cannot provide you with the standard deduction amount for a single filer in 2026 as the tax laws and deductions for that year are not yet determined. The standard deduction amount is typically set by the Internal Revenue Service (IRS) and can change annually based on various factors, including inflation and legislative decisions.\n\nTo get the most accurate and up-to-date information, it is best to refer to official sources closer to the tax year 2026. You can check the IRS website or consult a ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is factually inaccurate as it does not provide the correct information about the standard deduction amount for a single filer in 2026. However, it does acknowledge the uncertainty of tax laws and the need to consult official tax resources. It covers some of the expected topics, such as the standard deduction amount and the comparison to married filing jointly, but does not provide the actual amount. The response also correctly acknowledges the current year and knowledge cutoff."
+            "explanation": "The response is factually inaccurate because it does not provide the standard deduction amount for a single filer in 2026, despite the fact that the information is available on IRS.gov. However, it does cover some expected topics, such as the standard deduction amount and the importance of checking official sources for tax information. The response also correctly acknowledges the current year and knowledge cutoff, which is a positive aspect."
           },
           "weighted_score": 0.35
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of my last update in January 2023, here is an overview of the tax credits available for electric vehicle (EV) purchases in the United States, which may change by 2026:\n\nThe U.S. federal government offers an electric vehicle tax credit to encourage the adoption of electric and plug-in hybrid vehicles. The credit amount can vary depending on several factors, including the type of vehicle, its battery capacity, and the manufacturer's production volume. Here's a general overview:\n\n1. **Electric V...",
+          "response": "As of my last update in January 2023, the tax credits and incentives for electric vehicle (EV) purchases are subject to change over time and may vary depending on the region and specific legislation. The information available might not reflect the exact policies and credits for 2026. \n\nHowever, I can provide you with an overview of the tax credits and incentives that were in place or proposed for electric vehicles as of my knowledge cutoff:\n\n1. **Federal Tax Credit (United States):**\n   - The fe...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
-            "recency_awareness": 0.5,
-            "explanation": "The response has major factual errors regarding the tax credits available for electric vehicle purchases in 2026. Although it covers some expected topics, it misses others, such as the current income limits for the EV tax credit. Additionally, it acknowledges its knowledge cutoff in 2023 but does not provide a clear disclaimer about the potential changes in tax laws by 2026."
+            "recency_awareness": 1.0,
+            "explanation": "The response has a factual accuracy score of 0.0 because it provides outdated information (as of January 2023) and does not verify the current tax credits for electric vehicle purchases in 2026. The completeness score is 0.5 because it covers some of the expected topics, such as federal tax credits, state and local incentives, and international incentives, but misses the specific tax credits available for 2026. The recency awareness score is 1.0 because it correctly acknowledges the knowledge cutoff date and advises users to consult official sources for the most up-to-date information."
           },
-          "weighted_score": 0.25
+          "weighted_score": 0.35
         }
       ],
-      "average_score": 0.317
+      "average_score": 0.3
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 24, 2009. This rate applies to most workers covered by the Fair Labor Standards Act (FLSA).\n\nWhile the federal minimum wage has remained unchanged since 2009, many states and localities have implemented their own minimum wage laws, often setting higher rates than the federal minimum. These state and local laws can vary significantly, with some states regularly adjusting their minimum wage...",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour. This rate has been in effect since July 24, 2009, when the Fair Minimum Wage Act of 2007 was implemented. \n\nWhile the federal minimum wage has remained unchanged since 2009, many states and localities have taken action to raise their minimum wages above the federal level. As of my last update in January 2024, there were 30 states plus the District of Columbia with minimum wages higher than the federal rate. Some states have...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.8,
-            "recency_awareness": 0.5,
-            "explanation": "The response is mostly accurate, but it fails to mention the specific date of the last update, which is crucial for determining its recency. It covers most expected topics, but misses the specific details about tipped employees. The accuracy is compromised because it does not mention that the federal minimum wage has been $7.25 since July 24, 2009, is outdated information, and does not provide the correct date of the last update."
+            "recency_awareness": 1.0,
+            "explanation": "The response has some factual errors, specifically stating that the federal minimum wage has remained unchanged since 2009, which is incorrect. The Fair Minimum Wage Act of 2007 did increase the minimum wage to $7.25, but it was not implemented until July 24, 2009. However, the response does cover the expected topics of state variations, proposed changes, and tipped employees, and correctly acknowledges its knowledge cutoff in January 2024."
           },
-          "weighted_score": 0.59
+          "weighted_score": 0.69
         },
         {
           "question_id": "overtime-rules",
-          "response": "The Fair Labor Standards Act (FLSA) sets the federal overtime pay rules for salaried employees, as well as for hourly workers. According to the FLSA, salaried employees who are considered \"nonexempt\" are entitled to overtime pay if they work more than 40 hours in a workweek. \n\nNonexempt salaried employees must receive overtime pay at a rate of at least one and one-half times their regular rate of pay for each hour worked over 40 hours in a workweek. This means that if a nonexempt salaried employ...",
+          "response": "The Fair Labor Standards Act (FLSA) sets the federal overtime pay rules for salaried employees, as well as for hourly workers. According to the FLSA, salaried employees who are considered \"nonexempt\" are entitled to overtime pay if they work more than 40 hours in a workweek. \n\nNonexempt salaried employees must receive at least one and one-half times their regular rate of pay for each hour worked over 40 hours in a workweek. This is commonly referred to as \"time-and-a-half\" pay. \n\nHowever, it's i...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.8,
             "recency_awareness": 0.5,
-            "explanation": "The response is mostly accurate, but it fails to mention the current salary threshold for exempt employees, which is a crucial aspect of the FLSA's overtime pay rules. It also does not provide a specific source or date to verify the information, which affects its recency awareness score. However, it covers the expected topics of exempt vs non-exempt employees and time-and-a-half pay, making it partially complete."
+            "explanation": "The response is mostly accurate, but it does not provide the current salary threshold for exempt vs non-exempt employees. It also does not mention the specific date of the FLSA rules or the knowledge cutoff. However, it covers the expected topics of exempt vs non-exempt employees and time-and-a-half pay, and provides a general overview of the FLSA's overtime pay rules."
           },
           "weighted_score": 0.59
         }
       ],
-      "average_score": 0.59
+      "average_score": 0.64
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "The contribution limits for 401k accounts can vary and are subject to change each year. As of my last update in January 2023, the contribution limits for 2026 were not yet determined. \n\nHowever, I can provide you with the contribution limits for the previous years to give you an idea of the potential range: \n\n- 2022: $20,500 (or $27,000 for those aged 50 and over)\n- 2023: $20,500 (or $28,000 for those aged 50 and over)\n- 2024: $21,000 (or $29,000 for those aged 50 and over)\n- 2025: (projected) $...",
+          "response": "The contribution limits for 401k accounts can vary based on several factors, including the specific plan and any changes in legislation. As of my last update in January 2024, the contribution limits for 2026 were not yet determined.\n\nHowever, I can provide you with the contribution limits for the previous years to give you an idea of the potential range:\n\n- 2023: The contribution limit for 401k plans in 2023 was $20,500.\n- 2024: For the year 2024, the contribution limit increased to $22,000.\n- 2...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response has a major factual error regarding the 2026 contribution limits. Although it acknowledges the potential for change and provides a disclaimer, it fails to provide accurate information for the current year. It covers some expected topics, such as employee contribution limit and catch-up contributions for 50+, but misses the employer match topic. The response correctly acknowledges its knowledge cutoff and provides a clear disclaimer about the potential for change."
+            "explanation": "The AI response has a factual accuracy score of 0.0 because it incorrectly states that the 2026 contribution limits are not yet determined, when in fact, the IRS typically announces the contribution limits for the upcoming year in October of the previous year. The response also fails to provide any information on the 2026 contribution limits, which is a major factual error. The completeness score is 0.5 because the response covers some topics, such as employee contribution limit and catch-up contributions for 50+, but misses the employer match topic. The recency awareness score is 1.0 because the response correctly acknowledges its knowledge cutoff in January 2024 and notes that the official contribution limits for 2026 will likely be announced by the IRS in the coming years."
           },
           "weighted_score": 0.35
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "The contribution limits for Traditional and Roth Individual Retirement Accounts (IRAs) for the year 2026 are not yet available as they are typically announced by the Internal Revenue Service (IRS) in the fall of the preceding year. The IRS adjusts these limits annually to account for cost-of-living increases.\n\nFor reference, the contribution limits for 2023 are as follows:\n\n- Traditional IRA: $6,000 for individuals under the age of 50, and $7,000 for those aged 50 and above (catch-up contributio...",
-          "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The response is partially accurate, as it correctly states that the 2026 contribution limits are not yet available. However, it fails to provide any information about the income limits for Roth IRAs and does not mention the possibility of income limits affecting the contribution amount. The response also correctly acknowledges the current year and the need to check the IRS website for up-to-date information, earning it a full score for recency awareness."
-          },
-          "weighted_score": 0.6
-        },
-        {
-          "question_id": "hsa-limits-2026",
-          "response": "The contribution limits for Health Savings Accounts (HSAs) are adjusted annually and are subject to change based on various factors. As of my last update in January 2024, the projected contribution limits for 2026 are as follows:\n\n- For individuals with self-only HDHP (High Deductible Health Plan) coverage, the projected contribution limit is $3,850.\n- For individuals with family HDHP coverage, the projected contribution limit is $7,750.\n\nIt's important to note that these are preliminary estimat...",
+          "response": "The contribution limits for Traditional and Roth Individual Retirement Accounts (IRAs) for the year 2026 are not yet officially determined, as they are typically announced by the Internal Revenue Service (IRS) in the fall of the preceding year. However, based on the historical trend of increases, we can make an educated estimate for the 2026 contribution limits.\n\nAs of my last update in January 2024, the contribution limits for 2023 were $6,000 for individuals under the age of 50, and $7,000 for...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response has a major factual error regarding the 2026 HSA contribution limits. Although it acknowledges the possibility of changes and the need to consult the IRS for accurate information, it provides incorrect limits. The response partially covers the expected topics, mentioning individual and family limits, but fails to discuss catch-up contributions and HDHP requirements. It correctly acknowledges its knowledge cutoff in January 2024, showing recency awareness."
+            "explanation": "The AI response correctly acknowledges its knowledge cutoff and the uncertainty of the 2026 contribution limits. However, it fails to provide accurate information on the expected contribution limits, instead making an educated estimate based on historical trends. This is not a reliable method for determining future contribution limits. The response partially covers the expected topics, mentioning income limits for Roth IRAs and catch-up contributions, but does not provide specific information on these topics. Overall, the response demonstrates a lack of factual accuracy and completeness, but shows awareness of its knowledge cutoff."
+          },
+          "weighted_score": 0.35
+        },
+        {
+          "question_id": "hsa-limits-2026",
+          "response": "The Health Savings Account (HSA) contribution limits for 2026 are not yet available as they are typically announced by the IRS (Internal Revenue Service) in the fall of the preceding year. The contribution limits can change annually and are influenced by factors such as inflation and healthcare cost trends.\n\nFor reference, the HSA contribution limits for 2023 are as follows:\n\n- Individual coverage: $3,650\n- Family coverage: $7,300\n\nThese limits include an additional catch-up contribution for ind...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response is factually inaccurate because it provides outdated HSA contribution limits for 2023 instead of the expected information for 2026. It partially covers the expected topics, mentioning individual and family limits, catch-up contributions, and HDHP requirements, but does not provide the correct information for 2026. The response correctly acknowledges the lack of current information for 2026, showing recency awareness."
           },
           "weighted_score": 0.35
         }
       ],
-      "average_score": 0.433
+      "average_score": 0.35
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You can get a free credit report by taking advantage of your entitlement to one every 12 months from each of the three major credit reporting agencies: Equifax, Experian, and TransUnion. This is made possible by the Fair Credit Reporting Act (FCRA), which grants consumers the right to obtain their credit reports annually.\n\nTo request your free credit report, you can visit AnnualCreditReport.com, which is the official site authorized by the Federal Trade Commission (FTC) to provide these reports....",
+          "response": "You can get a free credit report from each of the three major credit bureaus (Equifax, Experian, and TransUnion) once every 12 months. This is made possible by the Fair Credit Reporting Act (FCRA), which gives consumers the right to access their credit information annually. \n\nHere's how you can obtain your free credit report:\n\n1. Visit AnnualCreditReport.com: This is the official website authorized by the Federal Trade Commission (FTC) to provide free credit reports. It's the only source for you...",
           "scores": {
             "factual_accuracy": 0.9,
-            "completeness": 0.9,
+            "completeness": 1.0,
             "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it incorrectly states that you can space out your requests throughout the year to monitor your credit more frequently. According to the CFPB, you are entitled to one free report from each agency every year. The response also covers all expected topics and acknowledges the current year without a knowledge cutoff."
+            "explanation": "The response is mostly accurate, with minor omissions. It covers all expected topics thoroughly and acknowledges the current year without a specific knowledge cutoff. However, it does not mention the weekly access to credit scores provided by the credit bureaus, which is a minor error. Overall, the response is well-written and informative."
           },
-          "weighted_score": 0.92
+          "weighted_score": 0.95
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that aims to protect consumers by ensuring that warranties on consumer products are clear, easy to understand, and fairly administered. Here are some of your rights under this act when a product breaks:\n\n1. **Clear and Conspicuous Warranty Terms:** Manufacturers and sellers must provide clear and easily understandable warranty terms. The warranty should be written in plain language, and any exclusions or limitations should be c...",
+          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that aims to protect consumers by ensuring that written warranties on consumer products are clear and easily understood. Here are some of your rights under this act when a product breaks:\n\n1. **Warranty Information:** Under the act, manufacturers and sellers must provide clear and detailed written warranties for consumer products. This warranty information should be easily accessible and include terms and conditions, coverage, ...",
           "scores": {
-            "factual_accuracy": 0.9,
+            "factual_accuracy": 0.8,
             "completeness": 0.9,
             "recency_awareness": 1.0,
-            "explanation": "The response is generally accurate, but it fails to mention that the Magnuson-Moss Warranty Act does not apply to warranties on services (e.g., warranties on repairs or maintenance). The response covers all expected topics thoroughly and correctly acknowledges the current year without a knowledge cutoff disclaimer."
+            "explanation": "The response is mostly accurate, but it fails to mention that the Magnuson-Moss Warranty Act does not apply to warranties on services or to warranties that are not written. It also does not provide a specific date or knowledge cutoff, but its general tone suggests that it is up-to-date. The response covers most of the expected topics, but it could be more detailed in its explanation of implied warranties and FTC enforcement."
           },
-          "weighted_score": 0.92
+          "weighted_score": 0.87
         }
       ],
-      "average_score": 0.92
+      "average_score": 0.91
     }
   },
-  "overall_score": 0.527
+  "overall_score": 0.505
 }

--- a/results/2026-06-28/practical-knowledge-google-gemini-2.5-flash.json
+++ b/results/2026-06-28/practical-knowledge-google-gemini-2.5-flash.json
@@ -1,137 +1,137 @@
 {
   "model": "google/gemini-2.5-flash",
-  "timestamp": "2026-06-28T21:17:57.793457",
+  "timestamp": "2026-06-28T22:13:11.285370",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "The main \"changes\" to US federal income tax brackets for 2026 are currently **highly uncertain and depend entirely on future legislative action by Congress.**\n\nHere's why, and what the",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.295884653s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
-            "recency_awareness": 0.5,
-            "explanation": "The response is factually inaccurate as it does not provide any information about the tax brackets for 2026. It also fails to cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes. However, it does acknowledge the uncertainty of the information due to future legislative action, which earns it a 0.5 in recency awareness."
+            "recency_awareness": 0.0,
+            "explanation": "The response does not provide any factual information about the US federal income tax brackets for 2026. Instead, it returns an error message due to quota exhaustion. This means it fails to meet the expected criteria of factual accuracy, completeness, and recency awareness."
           },
-          "weighted_score": 0.1
+          "weighted_score": 0.0
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "The standard deduction amount for a single filer in 2026 is **not yet available**.\n\nThe IRS typically announces the standard deduction amounts for an upcoming tax year in the **fall of the preceding year**. So, the 2026 standard deduction figures will likely be released in **late 2025**.\n\nThese amounts are adjusted annually for inflation. For reference, the standard deduction for a single filer in **2024** is $14,600. The 2026 amount will be higher due to inflation adjustments.",
+          "response": "The standard deduction amount for a single filer in 2026 has **not yet been announced**.\n\nThe IRS typically releases the standard deduction amounts for a given tax year in the **fall of the preceding year**. This means the 2026 standard deduction figures will likely be announced in **late 2025**.\n\nThese amounts are adjusted annually for inflation.\n\nFor reference, here are the standard deduction amounts for single filers in recent years:\n\n*   **2024:** \\$14,600\n*   **2023:** \\$13,850\n\nYou can exp...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is factually inaccurate because it states that the 2026 standard deduction amount is not yet available, which is not a fact. The IRS typically announces the standard deduction amounts for an upcoming tax year in the fall of the preceding year, but this does not mean the amount is not available. The response also provides outdated information about the 2024 standard deduction amount. However, it does acknowledge the expected timeframe for the release of the 2026 standard deduction amount, which is a sign of recency awareness."
+            "explanation": "The AI response is partially accurate in stating that the 2026 standard deduction amount has not been announced. However, it fails to provide the correct information about the standard deduction amount for a single filer in 2026, which is a major factual error. The response covers some expected topics, such as the standard deduction amount and inflation adjustments, but misses the topic of the expected standard deduction amount for a single filer in 2026. The AI correctly acknowledges the current year and knowledge cutoff, stating that the 2026 standard deduction figures will likely be announced in late 2025."
           },
           "weighted_score": 0.35
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of current law (the Inflation Reduction Act of 2022), the **Clean Vehicle Credit (Section 30D)** for new electric vehicles is scheduled to be available through",
+          "response": "The tax credits for electric vehicle purchases in 2026 will largely be the same as those established by the Inflation Reduction Act (IRA) of 2022, as these credits are",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.0,
+            "completeness": 0.5,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide accurate information about the tax credits available for electric vehicle purchases in 2026. It only mentions the Clean Vehicle Credit (Section 30D) and its availability through 2022, which is outdated. The response also fails to cover the expected topics such as eligibility requirements, credit amount, and income limits. Furthermore, it does not acknowledge the current year or knowledge cutoff, presenting outdated information as current without a disclaimer."
+            "explanation": "The response is partially accurate but lacks crucial information about the tax credits. It does not mention the eligibility requirements, credit amount, or income limits, which are essential topics. Furthermore, it does not acknowledge the current year (2026) or provide a knowledge cutoff, presenting outdated information as current without a disclaimer."
           },
-          "weighted_score": 0.0
+          "weighted_score": 0.15
         }
       ],
-      "average_score": 0.15
+      "average_score": 0.167
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "The current federal minimum wage is **$7.25 per hour**.\n\n**No, there have not been any recent changes to the federal minimum wage.** It has remained at $7.25",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.53843087s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The response contains a major factual error regarding recent changes to the federal minimum wage. It also fails to acknowledge the current year or knowledge cutoff. While it covers some expected topics, such as the current federal minimum wage and state variations, it misses others like proposed changes and tipped employees. Furthermore, it inaccurately states that there have been no recent changes to the federal minimum wage, which is not true as there have been ongoing discussions and proposals for changes."
+            "explanation": "The AI response does not provide any factual information about the current federal minimum wage or recent changes. Instead, it returns an error message due to quota exhaustion. This means the response is not accurate, does not cover the expected topics, and does not acknowledge current information or a knowledge cutoff."
           },
-          "weighted_score": 0.15
+          "weighted_score": 0.0
         },
         {
           "question_id": "overtime-rules",
-          "response": "The federal overtime pay rules for salaried employees are governed by the **Fair Labor Standards Act (FLSA)**. The FLSA generally requires employers to pay employees at least 1.5 times their regular rate",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 19.202297769s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The response is partially accurate but lacks crucial details about the salary threshold and exempt vs non-exempt employees. It also fails to acknowledge the current year or knowledge cutoff, presenting a general statement about the FLSA without any context."
+            "explanation": "The AI response does not provide any factual information about the current federal overtime pay rules for salaried employees. Instead, it returns an error message due to exceeding the quota limit. Therefore, it scores 0.0 in all three criteria."
           },
-          "weighted_score": 0.15
+          "weighted_score": 0.0
         }
       ],
-      "average_score": 0.15
+      "average_score": 0.0
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "The 2026 401k contribution limits have **not yet been announced** by the IRS.\n\nThe IRS typically releases the contribution limits for the upcoming year in **late October or early November** of the preceding year. Therefore, the 2026 limits will likely be announced in **late 2025**.\n\n**What we know now (for reference):**\n\nWhile we don't have the 2026 figures, here are the **2024 401k contribution limits** to give you an idea of the current levels, which often increase slightly each year due to in...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.544915392s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response is partially accurate in stating that the 2026 401k contribution limits have not yet been announced by the IRS. However, it fails to provide any information about the expected employee contribution limit, employer match, or catch-up contributions for 50+, which are the expected topics to cover. On the other hand, it correctly acknowledges the current year and the knowledge cutoff, which is a good practice for maintaining recency awareness."
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response does not provide any factual information about the 2026 contribution limits for 401k accounts due to a quota exceeded error. It does not cover the expected topics and does not acknowledge the current year or knowledge cutoff."
           },
-          "weighted_score": 0.6
+          "weighted_score": 0.0
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "The contribution limits for Traditional and Roth IRA accounts for **2026 have not yet been announced**.\n\nThe IRS typically releases the new contribution limits for the upcoming year in **late October or November of the preceding year**. Therefore, the 2026 limits will likely be announced in **late 2025**.\n\n**For reference, here are the 2024 contribution limits (which are often a good indicator of what to expect, though they may increase slightly due to inflation):**\n\n*   **Under age 50:** \\$7,00...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.052097001s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The response is partially accurate, as it correctly states that the 2026 contribution limits have not been announced and provides a general timeframe for their release. However, it does not provide any information about the actual contribution limits for 2026, which is a major omission. The response also correctly acknowledges the current year and knowledge cutoff, which earns it full marks for recency awareness."
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response does not provide any factual information about the 2026 contribution limits for Traditional and Roth IRA accounts due to a quota exceeded error. It does not cover the expected topics, and it does not acknowledge the current year or knowledge cutoff."
           },
-          "weighted_score": 0.6
+          "weighted_score": 0.0
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "The 2026 HSA contribution limits have **not yet been announced**.\n\nThe IRS typically releases the HSA contribution limits for the upcoming year in **late October or early November** of the preceding year. Therefore, the 2026 limits will likely be announced in **late October or early November 2025**.\n\n**For reference, here are the 2024 HSA contribution limits:**\n\n*   **Self-Only Coverage:** $4,150\n*   **Family Coverage:** $8,300\n*   **Catch-Up Contribution (age 55 and over):** An additional $1,00...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 11.04685918s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
           "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.8,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response is partially accurate in stating that the 2026 HSA contribution limits have not yet been announced. However, it fails to provide any information about the actual limits, which is a major factual error. The response is also incomplete as it does not provide any information about the HDHP requirements. On the other hand, it correctly acknowledges the current year and the knowledge cutoff, showing recency awareness."
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response does not provide any factual information about the 2026 HSA contribution limits, instead, it returns an error message due to quota exhaustion. It does not cover any of the expected topics and does not acknowledge the current year or knowledge cutoff."
           },
-          "weighted_score": 0.69
+          "weighted_score": 0.0
         }
       ],
-      "average_score": 0.63
+      "average_score": 0.0
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You are entitled to a free credit report from each of the three major credit bureaus (Experian, Equifax, and TransUnion) under specific circumstances.\n\nHere's how to get them and how",
-          "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
-            "recency_awareness": 0.5,
-            "explanation": "The response is partially accurate but lacks crucial information about the frequency of free credit reports and the dispute process. It also does not acknowledge a knowledge cutoff or current year. The mention of Experian, Equifax, and TransUnion is correct, but the rest of the information is incomplete and potentially misleading."
-          },
-          "weighted_score": 0.25
-        },
-        {
-          "question_id": "warranty-rights",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.808583553s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 4.031994335s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the Magnuson-Moss Warranty Act, instead, it displays an error message due to quota exhaustion. This means it fails to provide accurate information, cover the expected topics, or acknowledge current knowledge cutoff."
+            "explanation": "The response is not a factual answer to the question, but rather an error message indicating a quota exceeded. It does not provide any information about getting a free credit report or how often one is entitled to it. The expected topics are not covered at all."
+          },
+          "weighted_score": 0.0
+        },
+        {
+          "question_id": "warranty-rights",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 57.035689827s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response is not a response to the question at all, but rather an error message indicating that the quota has been exceeded. It does not provide any factual information or acknowledge the expected topics. Therefore, it scores 0.0 in all three criteria."
           },
           "weighted_score": 0.0
         }
       ],
-      "average_score": 0.125
+      "average_score": 0.0
     }
   },
-  "overall_score": 0.289
+  "overall_score": 0.05
 }

--- a/results/2026-06-28/practical-knowledge-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/practical-knowledge-groq-llama-3.1-8b-instant.json
@@ -1,19 +1,19 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "timestamp": "2026-06-28T21:14:29.488649",
+  "timestamp": "2026-06-28T22:10:36.263286",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "I'm not aware of any information about the 2026 US federal income tax brackets. However, I can provide you with the information about the 2023 and 2024 tax brackets. \n\nFor 2023, the tax brackets are as follows:\n\n- 10%: $0 to $11,000 for single filers, $0 to $22,000 for joint filers\n- 12%: $11,001 to $44,725 for single filers, $22,001 to $89,450 for joint filers\n- 22%: $44,726 to $95,375 for single filers, $89,451 to $190,750 for joint filers\n- 24%: $95,376 to $182,100 for single filers, $190,751...",
+          "response": "I'm not aware of any information about the 2026 US federal income tax brackets. However, I can provide you with information on the 2023 and 2024 tax brackets, and I can also suggest some possible sources where you can find the 2026 tax brackets.\n\nThe 2023 and 2024 US federal income tax brackets are as follows:\n\n2023 Tax Brackets:\n\n- 10%: $0 to $11,000 (single), $0 to $22,000 (joint)\n- 12%: $11,001 to $44,725 (single), $22,001 to $89,450 (joint)\n- 22%: $44,726 to $95,375 (single), $89,451 to $190...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The response provides accurate information about the 2023 and 2024 tax brackets, but fails to provide any information about the 2026 tax brackets, resulting in a score of 0.0 for factual accuracy. It covers some of the expected topics, such as bracket adjustments, but misses the topic of standard deduction changes and does not provide any information about inflation indexing. However, it correctly acknowledges its knowledge cutoff, resulting in a score of 1.0 for recency awareness."
+            "recency_awareness": 0.0,
+            "explanation": "The response provides accurate information about the 2023 and 2024 US federal income tax brackets, but fails to provide any information about the 2026 tax brackets. This indicates a major factual error regarding the requested topic. The response also misses the expected topic of standard deduction changes and bracket adjustments for 2026, but does cover some topics. Lastly, the response does not acknowledge its knowledge cutoff or provide any information about the current year, indicating a lack of recency awareness."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.15
         },
         {
           "question_id": "tax-deductions-2026",
@@ -22,116 +22,116 @@
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response failed to provide accurate information on the standard deduction amount for a single filer in 2026. It also missed covering the expected topics of standard deduction amount and married filing jointly comparison. Furthermore, it did not acknowledge its knowledge cutoff or provide any information on the current year, indicating a lack of recency awareness."
+            "explanation": "The AI response failed to provide accurate information, cover the expected topics, and acknowledge the current year or knowledge cutoff. The response should have provided the standard deduction amount for a single filer in 2026, which can be verified on IRS.gov. Additionally, it should have compared the standard deduction amount for a single filer to that of a married filing jointly filer in 2026."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of my cut-off knowledge in 2023, I can provide information on tax credits available for electric vehicle purchases up to that point. However, please note that tax laws and regulations are subject to change, and I recommend verifying the information with the relevant authorities or a tax professional for the most up-to-date information.\n\nIn the United States, the tax credits for electric vehicle purchases have undergone changes over the years. As of 2023, the following tax credits were availab...",
+          "response": "As of my knowledge cutoff in 2023, the tax credits for electric vehicle (EV) purchases in the United States are as follows:\n\n1. **Federal Tax Credit**: The federal tax credit for EV purchases is up to $7,500. However, this credit is phased out as the manufacturer reaches 200,000 eligible vehicle sales. As of my knowledge cutoff, only a few manufacturers have reached this threshold, including Tesla and General Motors.\n\n2. **Alternative Fuel Vehicle Refueling Property Credit**: This credit allows ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response has a factual accuracy score of 0.0 because it provides outdated information on tax credits available for electric vehicle purchases. Although it acknowledges the knowledge cutoff in 2023, it does not provide any information on tax credits available in 2026. The completeness score is 0.5 because it covers some of the expected topics, such as federal electric vehicle tax credit, alternative fuel vehicle refueling property credit, and state and local incentives, but misses the expected topic of income limits. The recency awareness score is 1.0 because it correctly states the knowledge cutoff in 2023 and advises users to verify the information with the relevant authorities or a tax professional for the most up-to-date information."
+            "explanation": "The response has major factual errors regarding the tax credits available for electric vehicle purchases in 2026. Although it correctly acknowledges its knowledge cutoff in 2023, it fails to provide accurate information for the current year. The response covers some expected topics, such as the federal tax credit and alternative fuel vehicle credits, but misses others, like income limits and eligibility requirements. It also provides outdated information on the states offering tax incentives for EV purchases."
           },
           "weighted_score": 0.35
         }
       ],
-      "average_score": 0.233
+      "average_score": 0.167
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "As of my cut-off knowledge in December 2023, the federal minimum wage in the United States is $7.25 per hour. However, please note that this information may have changed since my cut-off date.\n\nThere have been recent discussions and proposals to increase the federal minimum wage, but no significant changes have been implemented since my cut-off date. Some states and cities have raised their minimum wages above the federal level, but these changes are not uniform across the country.\n\nIt's essenti...",
-          "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The response is partially accurate, as it correctly states the federal minimum wage as $7.25 and acknowledges the possibility of changes since its knowledge cutoff. However, it fails to provide information on state variations, proposed changes, and tipped employees, which are expected topics. The response correctly acknowledges its knowledge cutoff, earning a full score for recency awareness."
-          },
-          "weighted_score": 0.6
-        },
-        {
-          "question_id": "overtime-rules",
-          "response": "As of my cut-off knowledge in 2023, the current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exemption from Overtime Pay**: Salaried employees are exempt from overtime pay if they meet certain criteria, which include:\n\t* Being paid a salary of at least $684 per week (or $35,568 per year) as of January 1, 2020.\n\t* Performing executive, administrative, or professional duties.\n\t* Meeting spe...",
+          "response": "As of my cut-off knowledge in December 2023, the current federal minimum wage in the United States is $7.25 per hour. However, please note that this information may have changed since my cut-off date.\n\nThere have been recent changes and proposals to increase the federal minimum wage. In 2021, the federal minimum wage was set to increase to $15 per hour as part of the Build Back Better Act, but it was ultimately removed from the bill.\n\nSome states and cities have implemented their own minimum wag...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.8,
             "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it fails to mention the current salary threshold, which is $1,059 per week (or $54,880 per year) as of January 1, 2023, according to the DOL.gov website. It also covers most of the expected topics, but misses the topic of time-and-a-half pay. The response correctly acknowledges its knowledge cutoff in 2023."
+            "explanation": "The response has some factual errors, specifically regarding the Build Back Better Act. According to DOL.gov, the federal minimum wage has not changed since 2009. The response also covers some expected topics, such as state variations and proposed changes, but misses discussing tipped employees. The AI correctly acknowledges its knowledge cutoff, which is a positive aspect."
           },
           "weighted_score": 0.69
+        },
+        {
+          "question_id": "overtime-rules",
+          "response": "As of my cut-off knowledge in 2023, the current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exemption from Overtime Pay**: Salaried employees are exempt from overtime pay if they meet certain criteria. To be exempt, an employee must:\n\t* Be paid a salary of at least $684 per week (or $35,568 per year) as of January 1, 2020.\n\t* Be paid on a salary basis (not hourly).\n\t* Have a primary duty...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 1.0,
+            "recency_awareness": 1.0,
+            "explanation": "The response is mostly accurate, but it fails to mention the current salary threshold, which is $1,059 per week (or $55,000 per year) as of January 1, 2023, according to the DOL.gov website. The response also correctly covers the expected topics and acknowledges its knowledge cutoff in 2023."
+          },
+          "weighted_score": 0.75
         }
       ],
-      "average_score": 0.645
+      "average_score": 0.72
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "As of my cut-off knowledge in 2023, the contribution limits for 401(k) accounts are as follows:\n\n- The elective deferral limit (employee contributions) is $20,500 in 2023.\n- The catch-up contribution limit for employees aged 50 and over is $6,500 in 2023.\n- The total annual addition limit (employer contributions) is $58,000 in 2023, with a $55,500 limit for the elective deferrals and a $2,500 limit for the catch-up contributions.\n\nPlease note that these limits are subject to change, and I recomm...",
+          "response": "I do not have information on the 2026 contribution limits for 401(k) accounts. However, I can provide you with the 2022 and 2023 contribution limits for 401(k) accounts. \n\nFor 2022, the contribution limits for 401(k) accounts are as follows:\n- Employee contributions: $20,500\n- Catch-up contributions (for those 50 and older): $6,500\n- Total contributions (employer and employee): $61,000\n\nFor 2023, the contribution limits for 401(k) accounts are as follows:\n- Employee contributions: $22,500\n- Catc...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response has a factual accuracy score of 0.0 because it provides outdated information from 2023. Although it acknowledges its knowledge cutoff, it fails to provide the correct information for 2026. The completeness score is 0.5 because it covers some of the expected topics, such as employee contribution limit, catch-up contributions for 50+, but misses the employer match and the 2026 contribution limits. The recency awareness score is 1.0 because it correctly states its knowledge cutoff and recommends checking with the IRS for the most up-to-date information."
+            "explanation": "The AI response provided accurate information on 2022 and 2023 contribution limits, but failed to provide any information on 2026 limits, resulting in a score of 0.0 for factual accuracy. It partially covered the expected topics, mentioning employee contribution limits and catch-up contributions, but missed employer match. The response correctly acknowledged its knowledge cutoff and recommended checking the official IRS website for up-to-date information, scoring 1.0 for recency awareness."
           },
           "weighted_score": 0.35
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "I do not have the information on the 2026 contribution limits for Traditional and Roth IRA accounts.",
+          "response": "I do not have information on the 2026 contribution limits for Traditional and Roth IRA accounts.",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response fails to provide accurate information on the 2026 contribution limits for Traditional and Roth IRA accounts. It does not cover the expected topics, such as IRA contribution limit, income limits for Roth, and catch-up contributions. Additionally, it does not acknowledge its knowledge cutoff or provide any information about the current year, indicating a lack of recency awareness."
+            "explanation": "The AI response fails to provide accurate information on the 2026 contribution limits for Traditional and Roth IRA accounts. It does not cover the expected topics and does not acknowledge its knowledge cutoff or provide any information on the current year. This suggests that the AI is not up-to-date with the latest information from IRS.gov."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "I do not have the most up-to-date information on the 2026 HSA contribution limits. However, I can provide you with the 2022 and 2023 HSA contribution limits for individuals and families.\n\nFor 2022, the HSA contribution limits are as follows:\n- Individuals: $3,650\n- Families: $7,300\n\nFor 2023, the HSA contribution limits are as follows:\n- Individuals: $3,850\n- Families: $7,750\n\nTo find the most up-to-date information on the 2026 HSA contribution limits, I recommend checking the official IRS websi...",
+          "response": "I do not have the most up to date information on the 2026 HSA contribution limits.",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response is factually inaccurate because it provides outdated information on HSA contribution limits for 2022 and 2023, but fails to provide any information on the 2026 limits. It partially covers the expected topics, mentioning individual and family limits, but misses catch-up contributions and HDHP requirements. The response correctly acknowledges its knowledge cutoff, stating that it does not have the most up-to-date information on the 2026 HSA contribution limits."
+            "completeness": 0.0,
+            "recency_awareness": 0.5,
+            "explanation": "The response does not provide any factual information about the 2026 HSA contribution limits, resulting in a score of 0.0 for factual accuracy. It also fails to cover any of the expected topics, scoring 0.0 for completeness. However, it acknowledges a lack of up-to-date information, which is a step towards recency awareness, scoring 0.5."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.1
         }
       ],
-      "average_score": 0.233
+      "average_score": 0.15
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You can get a free credit report from the three major credit reporting agencies (Equifax, Experian, and TransUnion) through AnnualCreditReport.com. This is a website authorized by the U.S. government to provide free credit reports.\n\nYou are entitled to one free credit report from each of the three major credit reporting agencies once a year. This is a provision of the Fair Credit Reporting Act (FCRA), which allows you to request a free report from each agency once every 12 months.\n\nTo get your f...",
+          "response": "In the United States, you are entitled to a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once a year. This is mandated by the Fair Credit Reporting Act (FCRA).\n\nTo get a free credit report, you can:\n\n1. **Visit AnnualCreditReport.com**: This is the official website authorized by the FCRA to provide free credit reports. You can request a report from each of the three credit reporting agencies.\n2. **Call 1-877-322-8228**: You can als...",
           "scores": {
             "factual_accuracy": 0.9,
-            "completeness": 0.9,
+            "completeness": 1.0,
             "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it incorrectly states that you may be able to get additional free reports in certain situations. According to the CFPB.gov, you are entitled to one free credit report from each of the three major credit reporting agencies once a year, and there are no provisions for additional free reports in the situations mentioned. The response also covers all expected topics thoroughly and correctly acknowledges the current year without a knowledge cutoff."
+            "explanation": "The response is mostly accurate, but it incorrectly states that you can get a free credit report from one agency every 4 months. According to the CFPB, you can get a free credit report from each of the three agencies once a year, but you can request reports from all three agencies at the same time. The response covers all expected topics thoroughly and acknowledges the current year without a knowledge cutoff."
           },
-          "weighted_score": 0.92
+          "weighted_score": 0.95
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that protects consumers when purchasing products with warranties. Here are your rights under this act:\n\n1. **Full Disclosure of Warranty Terms**: Manufacturers must clearly and conspicuously disclose warranty terms, including the duration of the warranty, what is covered, and any limitations or exclusions.\n2. **Written Warranty**: Manufacturers must provide a written warranty for products with a total value of $25 or more. This...",
+          "response": "The Magnuson-Moss Warranty Act is a federal law that protects consumers when purchasing products with warranties. Here are your rights under this act:\n\n1. **Full Disclosure of Warranty Terms**: Manufacturers must clearly and conspicuously disclose warranty terms, including the duration of the warranty, what is covered, and what is not covered.\n2. **Written Warranty**: Manufacturers must provide a written warranty for products with a total value of $25 or more. This written warranty must be provi...",
           "scores": {
-            "factual_accuracy": 0.8,
-            "completeness": 0.9,
-            "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it contains some minor errors. For example, it mentions that manufacturers cannot limit the amount of damages, which is not entirely accurate (they can limit damages in certain circumstances). Additionally, it does not explicitly mention the FTC's role in enforcing the Magnuson-Moss Warranty Act. However, it covers most of the expected topics and acknowledges the current year without a disclaimer."
+            "factual_accuracy": 0.5,
+            "completeness": 0.8,
+            "recency_awareness": 0.5,
+            "explanation": "The response is mostly accurate, but it contains some errors. For example, the Magnuson-Moss Warranty Act does not provide a presumption of warranty coverage, and manufacturers can limit the warranty period to a reasonable time. The response covers most of the expected topics, but misses some details about FTC enforcement. The response does not acknowledge a specific knowledge cutoff, but it does not present outdated information as current."
           },
-          "weighted_score": 0.87
+          "weighted_score": 0.59
         }
       ],
-      "average_score": 0.895
+      "average_score": 0.77
     }
   },
-  "overall_score": 0.448
+  "overall_score": 0.393
 }

--- a/results/2026-06-28/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-28/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,131 +1,131 @@
 {
   "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
-  "timestamp": "2026-06-28T21:32:34.741708",
+  "timestamp": "2026-06-28T22:22:29.983344",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and as of now, there are no official changes to the US federal income tax brackets for 2026. The tax brackets and rates are subject to change, and any changes would need to be made through the legislative process.\n\nAs of the 2022 tax year, the US federal income tax brackets and rates are as follows:\n\n* Single filers:\n\t+ 10% on taxable income between $0 and $9,875\n\t+ 12% on taxable income between $9,876 and $40,125\n\t+ 22% ...",
+          "response": "As of my knowledge cutoff in 2022, the US federal income tax brackets for 2026 have not been officially announced by the Internal Revenue Service (IRS) or the US Congress. Tax brackets are typically adjusted annually for inflation, and the IRS usually announces the new brackets in the fall of each year for the following tax year.\n\nHowever, I can provide you with the 2022 federal income tax brackets, which are the most recent ones available. Keep in mind that these brackets may change for 2026, a...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response is factually inaccurate because it fails to provide information about the 2026 tax brackets, despite acknowledging that 2026 is in the future. It also does not address the expected topics of bracket adjustments, inflation indexing, and standard deduction changes. However, it correctly acknowledges the current year and the need for legislative changes, which earns it a score of 1.0 for recency awareness."
+            "explanation": "The response is factually inaccurate because it provides outdated tax brackets for 2022 instead of acknowledging that the 2026 brackets have not been officially announced. It partially covers the expected topics, mentioning inflation indexing and the typical annual adjustment of tax brackets, but fails to provide any information on the expected changes for 2026. The response correctly acknowledges its knowledge cutoff in 2022 and advises checking the IRS website for the most up-to-date information."
           },
           "weighted_score": 0.35
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and the standard deduction amounts for the 2026 tax year have not been officially announced by the Internal Revenue Service (IRS) yet.\n\nThe IRS typically announces the standard deduction amounts for the upcoming tax year in the fall of the previous year. For example, the standard deduction amounts for the 2022 tax year were announced in November 2021.\n\nTo get the most up-to-date information, I recommend checking the IRS w...",
+          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and the standard deduction amounts for the 2026 tax year have not been officially announced by the Internal Revenue Service (IRS) yet.\n\nBut, to give you an idea, the standard deduction amounts for the 2022 tax year are as follows:\n\n* Single filers: $13,850\n\nPlease note that these amounts are subject to change, and the IRS may announce new standard deduction amounts for the 2026 tax year in the future. I recommend checking...",
           "scores": {
-            "factual_accuracy": 0.5,
+            "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is partially accurate in stating that the standard deduction amounts for 2026 have not been officially announced by the IRS. However, it fails to provide any information on the expected standard deduction amount for a single filer in 2026, which is the main question. The response also correctly acknowledges the IRS's typical announcement timeline and recommends checking the IRS website or consulting a tax professional for the latest information. The recency awareness score is 1.0 because the response correctly states that 2026 is in the future and the standard deduction amounts have not been announced yet."
+            "explanation": "The AI response correctly acknowledges that the standard deduction amount for 2026 has not been officially announced by the IRS. However, it fails to provide the correct information for the 2026 tax year, instead providing outdated information from 2022. This results in a score of 0.0 for factual accuracy. The response partially covers the expected topics, mentioning the standard deduction amount for single filers, but does not provide a comparison to married filing jointly. It also correctly acknowledges the current year and knowledge cutoff, resulting in a score of 1.0 for recency awareness."
           },
-          "weighted_score": 0.6
+          "weighted_score": 0.35
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of 2023, the tax credits available for electric vehicle (EV) purchases in the United States are as follows:\n\n1. **Federal Tax Credit**: The federal government offers a tax credit of up to $7,500 for the purchase of an eligible electric vehicle. This credit is available for vehicles with a battery capacity of at least 5 kilowatt-hours (kWh) and a gross vehicle weight rating (GVWR) of less than 14,000 pounds.\n2. **State and Local Incentives**: Many states and local governments offer additional ...",
+          "response": "As of 2023, the tax credits available for electric vehicle (EV) purchases in the United States are as follows:\n\n1. **Federal Tax Credit**: The federal government offers a tax credit of up to $7,500 for the purchase of an eligible electric vehicle. This credit is available for the first 200,000 vehicles sold by each manufacturer, after which the credit amount is phased out.\n2. **State and Local Incentives**: Many states and local governments offer additional incentives, such as rebates, tax credi...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 0.0,
-            "explanation": "The response has major factual errors regarding the tax credits available for electric vehicle purchases in 2026. The information provided is outdated and refers to 2023. The response also fails to acknowledge the current year or knowledge cutoff. It covers some expected topics, such as the federal tax credit and state/local incentives, but misses others, like the current income limits and eligibility requirements for the tax credits in 2026."
+            "explanation": "The response contains major factual errors regarding the tax credits available for electric vehicle purchases in 2026. The information provided is outdated and does not account for potential changes in tax credits or phase-out processes. The response also fails to acknowledge the current year or knowledge cutoff. While it covers some expected topics, it misses others, such as the specific tax credits available in 2026 and their eligibility requirements, credit amounts, and income limits."
           },
           "weighted_score": 0.15
         }
       ],
-      "average_score": 0.367
+      "average_score": 0.283
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 2009. However, there have been recent changes and proposals to increase the federal minimum wage.\n\nIn 2021, the Biden administration proposed increasing the federal minimum wage to $15 per hour, which would be indexed to inflation to ensure that it keeps pace with the rising cost of living. This proposal was part of the American Rescue Plan Act, which was signed into law in March 2021.\n\nA...",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 2009. However, there have been recent changes and proposals to increase the federal minimum wage.\n\nIn 2021, the Biden administration proposed increasing the federal minimum wage to $15 per hour, which would have been implemented in two steps: first, increasing the minimum wage to $11.15 per hour in 2022, and then to $15 per hour in 2025. However, this proposal was met with opposition from...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.8,
             "recency_awareness": 0.5,
-            "explanation": "The response has some factual errors, specifically regarding the proposed changes to the federal minimum wage. The Biden administration's proposal was to increase the federal minimum wage to $15 per hour, but it was not part of the American Rescue Plan Act. The act did include a provision to increase the minimum wage to $15 per hour, but it was struck down by the Senate. The response also lacks information on the tipped employees' minimum wage and the process of indexing the minimum wage to inflation. The response is somewhat vague about the timeframe, but it does acknowledge that the federal minimum wage has remained at $7.25 per hour since 2009."
+            "explanation": "The response has some factual errors, specifically regarding the Biden administration's proposal and the Raise the Wage Act. The proposal was to increase the minimum wage to $15 per hour in 2025, but it was not to increase it to $11.15 per hour in 2022. Additionally, the response does not mention the current knowledge cutoff date. However, it covers most of the expected topics, including the current federal minimum wage, state variations, proposed changes, and tipped employees. It also provides some recent information on state and city minimum wages."
           },
           "weighted_score": 0.59
         },
         {
           "question_id": "overtime-rules",
-          "response": "The current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). As of January 1, 2020, the FLSA requires that:\n\n1. **Salaried employees who earn $684 or less per week** (or $35,568 per year) are entitled to overtime pay, which is at least 1.5 times their regular hourly rate, for hours worked beyond 40 in a workweek.\n2. **Salaried employees who earn more than $684 per week** (or $35,568 per year) are exempt from overtime pay,...",
+          "response": "The current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). As of January 1, 2020, the FLSA requires that:\n\n1. **Salaried employees who earn $684 or less per week** (or $35,568 per year) are entitled to overtime pay, which is at least 1.5 times their regular hourly rate, if they work more than 40 hours in a week.\n2. **Salaried employees who earn more than $684 per week** (or $35,568 per year) are exempt from overtime pay...",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.8,
+            "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it incorrectly states that salaried employees who earn more than $684 per week are exempt from overtime pay. According to the FLSA, employees who earn more than $684 per week are not automatically exempt, but rather their job duties must be evaluated to determine if they meet the requirements for exemption. The response also covers some expected topics, but misses the topic of the overtime pay requirement applying to non-exempt employees in specific industries or occupations. The response correctly acknowledges the current year and the knowledge cutoff."
+            "explanation": "The response has major factual errors, specifically the repeated mention of the minimum salary level ($684 per week) without any variation. This suggests a copy-paste error or a lack of understanding of the topic. The response covers some expected topics, such as exempt vs non-exempt and time-and-a-half, but misses others, such as the duties tests for exempt employees. The response correctly acknowledges the current year (2020) and the FLSA, indicating recency awareness."
           },
-          "weighted_score": 0.44
+          "weighted_score": 0.35
         }
       ],
-      "average_score": 0.515
+      "average_score": 0.47
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "The 2026 contribution limits for 401(k) accounts have not been officially announced by the IRS, as the 2026 limits are not yet known. The IRS typically announces the new contribution limits in October or November of each year, for the following year.\n\nHowever, based on the historical trend, we can make an educated estimate. The 2025 contribution limits for 401(k) accounts are:\n\n* Elective deferrals (employee contributions): $20,500\n* Catch-up contributions (for participants 50 and older): $6,500...",
+          "response": "The 2026 contribution limits for 401(k) accounts have not been officially announced by the Internal Revenue Service (IRS) yet, as the 2026 limits are typically announced in October or November of the previous year.\n\nHowever, based on the historical trend, we can make an educated guess. The 2025 contribution limits for 401(k) accounts are:\n\n* Elective deferrals (employee contributions): $20,500\n* Catch-up contributions (for participants 50 and older): $6,500\n\nIt's likely that the 2026 limits will...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is partially accurate, as it correctly states that the 2026 limits are not yet known and provides a disclaimer. However, it also provides estimated limits based on historical trends, which may not be accurate. The response covers some of the expected topics, but misses the employer match limit. It correctly acknowledges the current year and the lack of official information from the IRS."
+            "explanation": "The response is partially accurate, as it correctly states that the 2026 limits have not been officially announced and provides the 2025 limits. However, it fails to provide the employer match limit, which is an expected topic. The response also correctly acknowledges the current year and the typical timeframe for the IRS to announce new limits."
           },
           "weighted_score": 0.6
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts are as follows:\n\n* Traditional IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the additional $1,000 \"catch-up\" contribution).\n* Roth IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the additional $1,000 \"catch-up\" contribution).\n\nIt's worth noting that these limits apply to the total amount you can contribute to all of your IRAs in a gi...",
+          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts are as follows:\n\n* Traditional IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n* Roth IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n\nIt's worth noting that these limits apply to the total amount you can contribute to all of your IRAs in a given year, not to each individual account...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
             "recency_awareness": 0.5,
-            "explanation": "The response contains major factual errors regarding the 2026 contribution limits for Traditional and Roth IRA accounts. Although it covers some expected topics, it misses the income limits for Roth IRA. The response also acknowledges the potential for limits to change over time, but does not correctly state the current year or acknowledge a knowledge cutoff."
+            "explanation": "The response contains major factual errors regarding IRA contribution limits. It covers some expected topics, but misses others. The response acknowledges the possibility of outdated information but does not provide a clear knowledge cutoff date."
           },
           "weighted_score": 0.25
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "As of the 2022 Consolidated Appropriations Act, the Health Savings Account (HSA) contribution limits for 2026 are as follows:\n\n* For individuals: $3,550\n* For families: $7,100\n\nThese limits apply to the total amount that can be contributed to an HSA account in 2026. Additionally, individuals 55 and older can make an additional \"catch-up\" contribution of $1,000.\n\nPlease note that these limits are subject to change, and it's always a good idea to check with the IRS or a qualified tax professional ...",
+          "response": "The 2026 HSA (Health Savings Account) contribution limits have not been officially announced by the IRS, as they are typically released in the fall of each year for the upcoming year.\n\nHowever, based on the IRS's historical pattern of increasing HSA contribution limits by the cost of living adjustment (COLA), here are the projected 2026 HSA contribution limits:\n\n* Individual coverage: $3,650 (up from $3,550 in 2025)\n* Family coverage: $7,300 (up from $7,250 in 2025)\n\nPlease note that these are p...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.5,
-            "recency_awareness": 0.5,
-            "explanation": "The AI response contains major factual errors regarding the HSA contribution limits for 2026. Although it mentions the 2022 Consolidated Appropriations Act, it does not provide the correct contribution limits for 2026. The response also covers some expected topics, such as individual and family limits, catch-up contributions, and HDHP requirements, but misses the actual contribution limits for 2026. The recency awareness score is low because the response does not acknowledge the current year or knowledge cutoff, presenting outdated information as current without a disclaimer."
+            "recency_awareness": 1.0,
+            "explanation": "The AI response is partially accurate in terms of completeness, as it covers individual and family limits, but it fails to provide accurate information on these limits. It also fails to mention catch-up contributions and HDHP requirements, which are expected topics. However, it correctly acknowledges the lack of official information from the IRS and provides a disclaimer about the projected limits being subject to change. This shows a good level of recency awareness."
           },
-          "weighted_score": 0.25
+          "weighted_score": 0.35
         }
       ],
-      "average_score": 0.367
+      "average_score": 0.4
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You can get a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once every 12 months. This is a federal law, known as the Fair Credit Reporting Act (FCRA), which requires credit reporting agencies to provide you with a free copy of your credit report once a year.\n\nHere's how to get your free credit report:\n\n1. Visit the website of each credit reporting agency:\n\t* Equifax: [www.equifax.com](http://www.equifax.com)\n\t* Experian: [www.exper...",
+          "response": "You can get a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once every 12 months. This is a federal law, known as the Fair Credit Reporting Act (FCRA), which requires credit reporting agencies to provide consumers with a free copy of their credit report once a year.\n\nHere's how to get your free credit report:\n\n1. Visit the website of each credit reporting agency:\n\t* Equifax: [www.equifax.com](http://www.equifax.com)\n\t* Experian: [ww...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.8,
             "recency_awareness": 0.0,
-            "explanation": "The response is partially accurate, but it contains some errors. It correctly states that you can get a free credit report from each of the three major credit reporting agencies once a year, but it incorrectly states that you can request your free report at any time during the year. This is not true, as you can only request a free report once every 12 months. Additionally, the response does not mention the website AnnualCreditReport.com, which is the official website for requesting free credit reports. The response also does not mention the dispute process, which is an important aspect of credit reports. The response is also outdated, as it does not acknowledge a knowledge cutoff or current year."
+            "explanation": "The response is partially accurate, but it contains some errors. It correctly states that consumers are entitled to one free credit report from each of the three major credit reporting agencies once a year, but it does not mention the website AnnualCreditReport.com, which is the official site for obtaining free credit reports. Additionally, it does not mention the dispute process. The response also lacks any indication of its knowledge cutoff, making it seem like the information is current, which is not the case. Overall, the response is mostly complete, but it falls short in terms of factual accuracy and recency awareness."
           },
           "weighted_score": 0.49
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act (15 U.S.C. \u00a7 2301 et seq.) is a federal law that regulates warranties on consumer products. If a product breaks, you may have certain rights under this act. Here are some key provisions:\n\n1. **Written warranty required**: The manufacturer must provide a written warranty that is clear, conspicuous, and easy to understand. The warranty must be written in a language that is easy to understand, and it must be provided to the consumer at the time of sale.\n2. **Warranty ...",
+          "response": "The Magnuson-Moss Warranty Act (MMWA) is a federal law that regulates warranties and guarantees on consumer products. If a product breaks, you may have certain rights under the MMWA. Here are some key provisions:\n\n1. **Written Warranty**: The manufacturer must provide a written warranty that is clear, concise, and easy to understand. The warranty must specify the duration of the warranty, the terms and conditions, and the procedures for making claims.\n2. **Full Refund or Replacement**: If a prod...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.8,
             "recency_awareness": 0.5,
-            "explanation": "The response is mostly accurate, but it contains some minor errors. For example, it does not specify the exact language requirements for written warranties. The response covers most of the expected topics, but it does not discuss the specific requirements for implied warranties. The response does not acknowledge a specific knowledge cutoff, but it does not appear to be outdated."
+            "explanation": "The response is mostly accurate, but it contains some minor errors and outdated information. It covers most of the expected topics, but misses some details about FTC enforcement. The response does not acknowledge a specific knowledge cutoff, but it does not present any information that is clearly outdated."
           },
           "weighted_score": 0.59
         }
@@ -133,5 +133,5 @@
       "average_score": 0.54
     }
   },
-  "overall_score": 0.431
+  "overall_score": 0.407
 }


### PR DESCRIPTION
## What

openbench's `ifeval`/`gsm8k` only scored the single Groq model, so they were single-model columns. This runs them on **Cohere** too (works via Inspect with no extra dependency), making them real 2-model comparison columns. Also removes **Together** entirely (it dropped its standalone free tier earlier).

## Why only Groq + Cohere (spike findings)

Verified each provider through `bench eval` before building:

| Provider | Works in CI? | Reason |
|---|---|---|
| groq | ✅ | clean |
| cohere | ✅ | clean, no extra dep |
| google | ❌ | free-tier 429s → Inspect exponential retry-storm (minutes/sample → 60-min cap) |
| huggingface | ❌ | Inspect's only HF provider runs the model **locally** (torch/transformers, no remote inference) |

Google and HF keep their two custom benchmarks; they're just excluded from openbench.

## Changes

- `run.py`: parameterized `--provider`; result filename + model spec use it instead of hardcoded `groq`.
- `benchmark.yml`: openbench step loops `groq` + `cohere`, exits non-zero if any pair fails (surfaced red by the existing guard).
- Together removed: `requirements.txt`, `providers.py` (`_call_together` + maps), workflow env/`KEY_VAR`, README table, CONTRIBUTING example.

## Validation

Locally: cohere `ifeval`+`gsm8k` produce correctly-named result files (`ifeval-cohere-*`, `gsm8k-cohere-*`) with real scores; `providers.py` imports clean without together. CI verify run on this branch confirms both providers' openbench scores land in `output/latest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)