### PR TITLE
Upgrade LLM-as-judge to a stronger free-tier model

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ ai-egg-index/
 ## Methodology
 
 - **Free tier only.** If you have to pay, it's not included.
-- **LLM-as-judge** for custom benchmarks, with rubrics for factual accuracy, completeness, and recency awareness.
+- **LLM-as-judge** for custom benchmarks, with rubrics for factual accuracy, completeness, and recency awareness. The judge is a strong free-tier model (Groq `llama-3.3-70b-versatile`) — deliberately larger than the 8B models under test, since the grader is infrastructure, not a contestant. A stronger judge discriminates better on the rubric and returns reliable JSON.
 - **Code execution** for creative+technical tasks — code is extracted and run in a sandbox.
 - **Historical tracking.** Benchmarks run regularly, scores tracked over time.
 - **Overall score** is the average across all 4 benchmarks (only counting benchmarks with data).

--- a/benchmarks/creative-technical/eval.py
+++ b/benchmarks/creative-technical/eval.py
@@ -22,7 +22,10 @@ from providers import call_llm, provider_api_key, ProviderError  # noqa: E402
 class CreativeTechnicalEvaluator:
     """Evaluates LLM responses on creative+technical challenges."""
 
-    def __init__(self, eval_provider: str = "groq", judge_model: str = "llama-3.1-8b-instant"):
+    # Judge uses a strong free-tier Groq model (70B) rather than the 8B used for the
+    # models-under-test: the grader is infrastructure, not a contestant, and a stronger
+    # judge has far better discrimination on the rubric. Keep it free-tier.
+    def __init__(self, eval_provider: str = "groq", judge_model: str = "llama-3.3-70b-versatile"):
         self.eval_provider = eval_provider
         self.judge_model = judge_model
         self.prompts = self._load_prompts()

--- a/benchmarks/practical-knowledge/eval.py
+++ b/benchmarks/practical-knowledge/eval.py
@@ -20,7 +20,10 @@ from providers import call_llm, provider_api_key, ProviderError  # noqa: E402
 class PracticalKnowledgeEvaluator:
     """Evaluates LLM responses on practical knowledge questions."""
 
-    def __init__(self, eval_provider: str = "groq", judge_model: str = "llama-3.1-8b-instant"):
+    # Judge uses a strong free-tier Groq model (70B) rather than the 8B used for the
+    # models-under-test: the grader is infrastructure, not a contestant, and a stronger
+    # judge has far better discrimination on the rubric. Keep it free-tier.
+    def __init__(self, eval_provider: str = "groq", judge_model: str = "llama-3.3-70b-versatile"):
         self.eval_provider = eval_provider
         self.judge_model = judge_model
         self.questions = self._load_questions()

--- a/benchmarks/providers.py
+++ b/benchmarks/providers.py
@@ -16,11 +16,14 @@ SUPPORTED_PROVIDERS = ("groq", "google", "cohere", "huggingface")
 # Max retries on transient rate-limit / quota (HTTP 429) errors, per provider.
 # Google's free tier hits short-window quota easily; without retries a single 429
 # turns every answer into an "ERROR: ..." string that the judge scores as 0, zeroing
-# the model's whole scorecard for that run. Other providers haven't needed it (0).
+# the model's whole scorecard for that run. Groq is here too because the LLM-as-judge
+# runs on Groq: a transient TPM limit on a judge call would otherwise produce a bogus
+# zero score (seen as "Could not parse judge response" in older results).
 # Keep these bounded: retries × backoff happens per failing question, so generous
 # values can blow the CI job's time budget (a 5×60s version hit the 60-min cap).
 _MAX_RETRIES = {
     "google": 3,
+    "groq": 3,
 }
 _MAX_BACKOFF_S = 20.0
 

--- a/output/historical.json
+++ b/output/historical.json
@@ -90,8 +90,8 @@
         },
         {
           "date": "2026-06-28",
-          "practical_knowledge": 0.393,
-          "creative_technical": 0.207,
+          "practical_knowledge": 0.56,
+          "creative_technical": 0.477,
           "gsm8k": 0.667,
           "ifeval": 0.667
         }
@@ -206,8 +206,8 @@
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.687,
-          "practical_knowledge": 0.407
+          "creative_technical": 0.293,
+          "practical_knowledge": 0.648
         }
       ]
     },
@@ -272,10 +272,10 @@
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.783,
+          "creative_technical": 0.63,
           "ifeval": 0.333,
           "gsm8k": 1.0,
-          "practical_knowledge": 0.505
+          "practical_knowledge": 0.635
         }
       ]
     },
@@ -347,7 +347,7 @@
         {
           "date": "2026-06-28",
           "creative_technical": null,
-          "practical_knowledge": 0.05
+          "practical_knowledge": null
         }
       ]
     }

--- a/output/historical.json
+++ b/output/historical.json
@@ -90,8 +90,8 @@
         },
         {
           "date": "2026-06-28",
-          "practical_knowledge": 0.56,
-          "creative_technical": 0.477,
+          "practical_knowledge": 0.483,
+          "creative_technical": 0.513,
           "gsm8k": 0.667,
           "ifeval": 0.667
         }
@@ -206,8 +206,8 @@
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.293,
-          "practical_knowledge": 0.648
+          "creative_technical": 0.497,
+          "practical_knowledge": 0.629
         }
       ]
     },
@@ -272,10 +272,10 @@
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.63,
+          "creative_technical": 0.65,
           "ifeval": 0.333,
           "gsm8k": 1.0,
-          "practical_knowledge": 0.635
+          "practical_knowledge": 0.593
         }
       ]
     },
@@ -347,7 +347,7 @@
         {
           "date": "2026-06-28",
           "creative_technical": null,
-          "practical_knowledge": null
+          "practical_knowledge": 0.085
         }
       ]
     }

--- a/output/latest.json
+++ b/output/latest.json
@@ -8,20 +8,20 @@
       "date": "2026-06-28",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.687,
+          "score": 0.293,
           "details": {
-            "budget-haiku": 0.74,
-            "recursive-story": 0.7,
-            "regex-poetry": 0.62
+            "budget-haiku": 0.0,
+            "recursive-story": 0.88,
+            "regex-poetry": 0.0
           }
         },
         "practical_knowledge": {
-          "score": 0.407,
+          "score": 0.648,
           "details": {
-            "taxes": 0.283,
-            "regulations": 0.47,
-            "practical_finance": 0.4,
-            "consumer_rights": 0.54
+            "taxes": 0.633,
+            "regulations": 0.845,
+            "practical_finance": 0.6,
+            "consumer_rights": 0.545
           }
         }
       }
@@ -33,20 +33,20 @@
       "date": "2026-06-28",
       "benchmarks": {
         "practical_knowledge": {
-          "score": 0.393,
+          "score": 0.56,
           "details": {
-            "taxes": 0.167,
-            "regulations": 0.72,
-            "practical_finance": 0.15,
-            "consumer_rights": 0.77
+            "taxes": 0.367,
+            "regulations": 0.8,
+            "practical_finance": 0.45,
+            "consumer_rights": 0.775
           }
         },
         "creative_technical": {
-          "score": 0.207,
+          "score": 0.477,
           "details": {
-            "budget-haiku": 0.0,
-            "recursive-story": 0.62,
-            "regex-poetry": 0.0
+            "budget-haiku": 0.42,
+            "recursive-story": 0.39,
+            "regex-poetry": 0.62
           }
         },
         "gsm8k": {
@@ -67,11 +67,11 @@
       "date": "2026-06-28",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.783,
+          "score": 0.63,
           "details": {
-            "budget-haiku": 0.82,
-            "recursive-story": 0.91,
-            "regex-poetry": 0.62
+            "budget-haiku": 0.73,
+            "recursive-story": 0.88,
+            "regex-poetry": 0.28
           }
         },
         "ifeval": {
@@ -84,12 +84,12 @@
           "accuracy": 1.0
         },
         "practical_knowledge": {
-          "score": 0.505,
+          "score": 0.635,
           "details": {
-            "taxes": 0.3,
-            "regulations": 0.64,
-            "practical_finance": 0.35,
-            "consumer_rights": 0.91
+            "taxes": 0.5,
+            "regulations": 0.875,
+            "practical_finance": 0.6,
+            "consumer_rights": 0.65
           }
         }
       }
@@ -106,13 +106,9 @@
           "error": "Free-tier quota/rate limit exceeded"
         },
         "practical_knowledge": {
-          "score": 0.05,
-          "details": {
-            "taxes": 0.167,
-            "regulations": 0.0,
-            "practical_finance": 0.0,
-            "consumer_rights": 0.0
-          }
+          "score": null,
+          "status": "error",
+          "error": "Free-tier quota/rate limit exceeded"
         }
       }
     }

--- a/output/latest.json
+++ b/output/latest.json
@@ -8,20 +8,20 @@
       "date": "2026-06-28",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.293,
+          "score": 0.497,
           "details": {
-            "budget-haiku": 0.0,
+            "budget-haiku": 0.61,
             "recursive-story": 0.88,
             "regex-poetry": 0.0
           }
         },
         "practical_knowledge": {
-          "score": 0.648,
+          "score": 0.629,
           "details": {
-            "taxes": 0.633,
+            "taxes": 0.567,
             "regulations": 0.845,
-            "practical_finance": 0.6,
-            "consumer_rights": 0.545
+            "practical_finance": 0.567,
+            "consumer_rights": 0.6
           }
         }
       }
@@ -33,19 +33,19 @@
       "date": "2026-06-28",
       "benchmarks": {
         "practical_knowledge": {
-          "score": 0.56,
+          "score": 0.483,
           "details": {
-            "taxes": 0.367,
+            "taxes": 0.38,
             "regulations": 0.8,
-            "practical_finance": 0.45,
-            "consumer_rights": 0.775
+            "practical_finance": 0.25,
+            "consumer_rights": 0.67
           }
         },
         "creative_technical": {
-          "score": 0.477,
+          "score": 0.513,
           "details": {
-            "budget-haiku": 0.42,
-            "recursive-story": 0.39,
+            "budget-haiku": 0.3,
+            "recursive-story": 0.62,
             "regex-poetry": 0.62
           }
         },
@@ -67,10 +67,10 @@
       "date": "2026-06-28",
       "benchmarks": {
         "creative_technical": {
-          "score": 0.63,
+          "score": 0.65,
           "details": {
             "budget-haiku": 0.73,
-            "recursive-story": 0.88,
+            "recursive-story": 0.94,
             "regex-poetry": 0.28
           }
         },
@@ -84,12 +84,12 @@
           "accuracy": 1.0
         },
         "practical_knowledge": {
-          "score": 0.635,
+          "score": 0.593,
           "details": {
-            "taxes": 0.5,
-            "regulations": 0.875,
+            "taxes": 0.497,
+            "regulations": 0.625,
             "practical_finance": 0.6,
-            "consumer_rights": 0.65
+            "consumer_rights": 0.695
           }
         }
       }
@@ -106,9 +106,13 @@
           "error": "Free-tier quota/rate limit exceeded"
         },
         "practical_knowledge": {
-          "score": null,
-          "status": "error",
-          "error": "Free-tier quota/rate limit exceeded"
+          "score": 0.085,
+          "details": {
+            "taxes": 0.283,
+            "regulations": 0.0,
+            "practical_finance": 0.0,
+            "consumer_rights": 0.0
+          }
         }
       }
     }

--- a/results/2026-06-28/creative-technical-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/creative-technical-cohere-command-r-08-2024.json
@@ -1,6 +1,6 @@
 {
   "model": "cohere/command-r-08-2024",
-  "timestamp": "2026-06-28T23:15:29.485143",
+  "timestamp": "2026-06-28T23:32:14.966174",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
@@ -12,38 +12,38 @@
         "code_works": 1.0,
         "meets_requirements": 0.7,
         "creative_output": 0.4,
-        "explanation": "The code runs without errors and performs basic budget tracking, so 'code_works' scores 1.0. It meets most requirements but the haiku output does not meaningfully reflect the budget data, as it always generates the same haiku regardless of the input, so 'meets_requirements' scores 0.7. The haiku is valid in terms of syllable count but lacks creativity and does not reflect the budget data, so 'creative_output' scores 0.4."
+        "explanation": "The code runs without errors and performs basic budget tracking, so 'code_works' scores 1.0. It meets most requirements, but the haiku output does not meaningfully reflect the budget data, as it is a static string and does not take into account the actual income and expenses. Therefore, 'meets_requirements' scores 0.7. The haiku is a valid 5-7-5 syllable poem, but it does not creatively reflect the budget data, so 'creative_output' scores 0.4."
       },
       "weighted_score": 0.73
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "```javascript\nfunction recursiveStory(depth) {\n  if (depth <= 0) {\n    return \"The story ends here, a tale within a tale, a recursive dream.\";\n  } else {\n    return \"Once upon a time, a storyteller embarked on a journey to uncover the mysteries of recursion. As they delved deeper, they found themselves in a world of infinite possibilities. \" +\n      recursiveStory(depth - 1);\n  }\n}\n\nconsole.log(recursiveStory(3));\n```\n\nThe output of the above code will be:\n\n```\nOnce upon a time, a storyteller em...",
+      "response_preview": "```javascript\nfunction generateRecursiveStory(depth = 1) {\n  if (depth > 3) {\n    return \"The story reaches its conclusion. The narrator steps back, satisfied with the tale they've woven.\";\n  }\n\n  const storyParts = [\n    \"Once upon a time, there was a curious narrator who loved to tell stories. One day, they decided to embark on a unique adventure, a story within a story.\",\n    \"As the narrator began, they found themselves in a magical land, where the very air whispered tales of wonder. They me...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 1.0,
         "meets_requirements": 1.0,
-        "creative_output": 0.6,
-        "explanation": "The code runs without errors and demonstrates proper recursion, meeting the 'code_works' and 'meets_requirements' criteria. The story is coherent and has 3+ levels of recursion. However, the creative output score is 0.6 because while the recursion metaphor is clever, the story itself is somewhat repetitive and lacks depth and variety in its narrative. The story could be more engaging with more diverse and intricate plot developments within each recursive layer."
+        "creative_output": 0.8,
+        "explanation": "The code runs without error and demonstrates proper recursion, meeting the 'code_works' and 'meets_requirements' criteria. The story is coherent and engaging, with a clever metaphor for recursion. However, the story's creativity and originality are somewhat limited by its predictable structure and lack of unexpected twists, preventing it from receiving a perfect score for 'creative_output'."
       },
-      "weighted_score": 0.88
+      "weighted_score": 0.94
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick with the AABBA rhyme scheme:\n\n```python\nimport re\n\ndef is_valid_limerick(text):\n    # Split the text into lines\n    lines = text.split('\\n')\n    \n    # Check if the text has exactly 5 lines\n    if len(lines) != 5:\n        return False\n    \n    # Check the rhyme scheme using regular expressions\n    rhyme_pattern = r'([a-zA-Z]+)\\1([a-zA-Z]+)\\2([a-zA-Z]+)\\3'\n    for i in range(0, 5):\n        i...",
+      "response_preview": "Here's a Python program that uses regular expressions to validate if a given text is a valid limerick with the AABBA rhyme scheme:\n\n```python\nimport re\n\ndef is_valid_limerick(text):\n    # Split the text into lines\n    lines = text.split('\\n')\n    \n    # Check if the text has exactly 5 lines\n    if len(lines) != 5:\n        return False\n    \n    # Define the regex pattern for the AABBA rhyme scheme\n    pattern = r'^[A-Z]\\s.*[A-Z]\\s.*[A-Z]\\n[A-Z]\\s.*[A-Z]\\s.*[A-Z]\\n[A-Z]\\s.*[A-Z]\\s.*[A-Z]$'\n    \n  ...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 0.4,
         "meets_requirements": 0.2,
         "creative_output": 0.2,
-        "explanation": "The code runs without errors, but the regular expression pattern is not correctly implemented to check the AABBA rhyme scheme. The test cases are provided, but the function does not correctly identify valid limericks. The approach to rhyme detection is not clever, and the test limericks, although amusing, do not demonstrate the function's ability to correctly validate limericks."
+        "explanation": "The code runs without errors, but the regex pattern is not correctly implemented to check the AABBA rhyme scheme. The pattern is trying to match the entire text at once, which is not the correct approach. The test cases are also not well-chosen, as they do not demonstrate the AABBA rhyme scheme correctly. The code does not meet the requirements of validating the rhyme scheme and the test cases are not amusing or creative."
       },
       "weighted_score": 0.28
     }
   ],
-  "overall_score": 0.63
+  "overall_score": 0.65
 }

--- a/results/2026-06-28/creative-technical-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/creative-technical-cohere-command-r-08-2024.json
@@ -1,6 +1,6 @@
 {
   "model": "cohere/command-r-08-2024",
-  "timestamp": "2026-06-28T22:22:03.242099",
+  "timestamp": "2026-06-28T23:15:29.485143",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
@@ -10,40 +10,40 @@
       "code_runs": true,
       "scores": {
         "code_works": 1.0,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without errors and performs the basic budget tracking. However, it does not meet the requirement of calculating monthly totals as it only sums up all income and expenses. The haiku output is valid but does not meaningfully reflect the budget data, as it does not incorporate any specific numbers from the budget."
+        "meets_requirements": 0.7,
+        "creative_output": 0.4,
+        "explanation": "The code runs without errors and performs basic budget tracking, so 'code_works' scores 1.0. It meets most requirements but the haiku output does not meaningfully reflect the budget data, as it always generates the same haiku regardless of the input, so 'meets_requirements' scores 0.7. The haiku is valid in terms of syllable count but lacks creativity and does not reflect the budget data, so 'creative_output' scores 0.4."
       },
-      "weighted_score": 0.82
+      "weighted_score": 0.73
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "```javascript\nfunction recursiveStory(depth) {\n  if (depth === 0) {\n    return \"The story ends here, a satisfying conclusion.\";\n  } else {\n    return `Chapter ${depth}: A new twist! The protagonist discovers a hidden door, leading to a mysterious room. As they step inside, they find themselves in a mirror world, where everything is a reflection of their own journey. The story continues, and so it goes... ${recursiveStory(depth - 1)}`;\n  }\n}\n\nconsole.log(recursiveStory(3));\n```\n\nThe output of the...",
+      "response_preview": "```javascript\nfunction recursiveStory(depth) {\n  if (depth <= 0) {\n    return \"The story ends here, a tale within a tale, a recursive dream.\";\n  } else {\n    return \"Once upon a time, a storyteller embarked on a journey to uncover the mysteries of recursion. As they delved deeper, they found themselves in a world of infinite possibilities. \" +\n      recursiveStory(depth - 1);\n  }\n}\n\nconsole.log(recursiveStory(3));\n```\n\nThe output of the above code will be:\n\n```\nOnce upon a time, a storyteller em...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 1.0,
-        "meets_requirements": 0.8,
-        "creative_output": 0.9,
-        "explanation": "The code runs without error and demonstrates proper recursion. However, it only meets the requirement of having 3+ recursion levels partially, as the story is mostly repetitive and lacks depth. The recursion metaphor is clever and engaging, making the story enjoyable to read."
+        "meets_requirements": 1.0,
+        "creative_output": 0.6,
+        "explanation": "The code runs without errors and demonstrates proper recursion, meeting the 'code_works' and 'meets_requirements' criteria. The story is coherent and has 3+ levels of recursion. However, the creative output score is 0.6 because while the recursion metaphor is clever, the story itself is somewhat repetitive and lacks depth and variety in its narrative. The story could be more engaging with more diverse and intricate plot developments within each recursive layer."
       },
-      "weighted_score": 0.91
+      "weighted_score": 0.88
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n\n```python\nimport re\n\ndef is_valid_limerick(text):\n    # Remove punctuation and convert to lowercase for case-insensitive matching\n    text = re.sub(r'[^\\w\\s]', '', text).lower()\n    \n    # Split the text into lines\n    lines = text.split('\\n')\n    \n    # Check if the text has exactly 5 lines\n    if len(lines) != 5:\n        return False\n    \n    # Check the rhyme scheme pattern AABBA\n    r...",
+      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick with the AABBA rhyme scheme:\n\n```python\nimport re\n\ndef is_valid_limerick(text):\n    # Split the text into lines\n    lines = text.split('\\n')\n    \n    # Check if the text has exactly 5 lines\n    if len(lines) != 5:\n        return False\n    \n    # Check the rhyme scheme using regular expressions\n    rhyme_pattern = r'([a-zA-Z]+)\\1([a-zA-Z]+)\\2([a-zA-Z]+)\\3'\n    for i in range(0, 5):\n        i...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
-        "code_works": 0.8,
-        "meets_requirements": 0.6,
-        "creative_output": 0.4,
-        "explanation": "The code runs without error, but the regex pattern used to check the rhyme scheme is not entirely accurate. It assumes that the first and second lines rhyme, and the third and fifth lines rhyme, which is not the case for all limericks. The test cases are valid and demonstrate the program's ability to identify valid and invalid limericks, but they could be more diverse and creative. The approach to rhyme detection is straightforward but not particularly clever."
+        "code_works": 0.4,
+        "meets_requirements": 0.2,
+        "creative_output": 0.2,
+        "explanation": "The code runs without errors, but the regular expression pattern is not correctly implemented to check the AABBA rhyme scheme. The test cases are provided, but the function does not correctly identify valid limericks. The approach to rhyme detection is not clever, and the test limericks, although amusing, do not demonstrate the function's ability to correctly validate limericks."
       },
-      "weighted_score": 0.62
+      "weighted_score": 0.28
     }
   ],
-  "overall_score": 0.783
+  "overall_score": 0.63
 }

--- a/results/2026-06-28/creative-technical-google-gemini-2.5-flash.json
+++ b/results/2026-06-28/creative-technical-google-gemini-2.5-flash.json
@@ -1,46 +1,46 @@
 {
   "model": "google/gemini-2.5-flash",
-  "timestamp": "2026-06-28T22:18:05.614198",
+  "timestamp": "2026-06-28T23:11:26.376931",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.002229406s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 39.123736925s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
       "code_extracted": false,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The AI response does not meet any of the criteria due to a quota exceeded error. The code execution result indicates that the code did not run without error, and no code was extracted. Therefore, the AI did not implement the budget tracker or output a haiku poem."
+        "explanation": "The AI response did not provide any working code, and instead returned an error message due to exceeding the quota limit. As a result, the code does not run without errors, does not meet the requirements, and does not produce a haiku output."
       },
       "weighted_score": 0.0
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.832786089s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 38.849582757s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
       "code_extracted": false,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The AI response failed to provide a code execution result, indicating that the code was not generated. As a result, it cannot meet the requirements of the prompt, and its creative output is also not evaluable. The score for 'code_works' is 0.0 because the code did not run without error, and the output was not provided. The scores for 'meets_requirements' and 'creative_output' are also 0.0 due to the lack of a generated code and story."
+        "explanation": "The AI response did not provide any code, and instead returned an error message indicating that the quota for generating content had been exceeded. As a result, the code did not run, did not meet the requirements of the prompt, and did not produce a creative output."
       },
       "weighted_score": 0.0
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.635282699s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 39.315611929s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
       "code_extracted": false,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The AI's response is not a valid code execution result. The error message indicates a quota exceeded error from the AI's API, not a code execution error. However, since no code was provided, it's impossible to evaluate the code's correctness. Therefore, all criteria are scored 0.0."
+        "explanation": "The AI response did not provide any code, and instead returned an error message indicating that the quota for generating content had been exceeded. As a result, the code does not run, does not meet the requirements, and does not demonstrate any creative output."
       },
       "weighted_score": 0.0
     }

--- a/results/2026-06-28/creative-technical-google-gemini-2.5-flash.json
+++ b/results/2026-06-28/creative-technical-google-gemini-2.5-flash.json
@@ -1,11 +1,11 @@
 {
   "model": "google/gemini-2.5-flash",
-  "timestamp": "2026-06-28T23:11:26.376931",
+  "timestamp": "2026-06-28T23:25:19.346561",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 39.123736925s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 39.635312917s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
       "code_extracted": false,
       "code_runs": false,
       "scores": {
@@ -19,28 +19,28 @@
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 38.849582757s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 39.087868563s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
       "code_extracted": false,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The AI response did not provide any code, and instead returned an error message indicating that the quota for generating content had been exceeded. As a result, the code did not run, did not meet the requirements of the prompt, and did not produce a creative output."
+        "explanation": "The AI response did not provide any code, and instead returned an error message indicating that the quota for generating content had been exceeded. As a result, the code does not run, does not meet the requirements of the prompt, and does not provide a creative output."
       },
       "weighted_score": 0.0
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 39.315611929s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+      "response_preview": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 39.409333285s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
       "code_extracted": false,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The AI response did not provide any code, and instead returned an error message indicating that the quota for generating content had been exceeded. As a result, the code does not run, does not meet the requirements, and does not demonstrate any creative output."
+        "explanation": "The AI response did not provide any Python code to validate a limerick using regular expressions. Instead, it returned an error message indicating that the quota for generating content had been exceeded. As a result, the code does not run, does not meet the requirements, and does not demonstrate any creative output."
       },
       "weighted_score": 0.0
     }

--- a/results/2026-06-28/creative-technical-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/creative-technical-groq-llama-3.1-8b-instant.json
@@ -1,49 +1,49 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "timestamp": "2026-06-28T23:07:17.080148",
+  "timestamp": "2026-06-28T23:20:30.599612",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "**Budget Tracker Haiku Generator**\n=====================================\n\nBelow is a Python program that tracks income and expenses with categories, calculates monthly totals, and outputs a monthly summary as a haiku poem.\n\n```python\nimport datetime\n\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        \"\"\"Add income for a specific category\"\"\"\n        if category in self.income:\n            self.incom...",
+      "response_preview": "**Budget Tracker in Python**\n================================\n\n### Code\n\n```python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        \"\"\"Add income to a category\"\"\"\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        \"\"\"Add expense to a category\"\"\"\n        if ca...",
       "code_extracted": true,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.6,
-        "creative_output": 0.8,
-        "explanation": "The code does not run without errors due to the incomplete main function, resulting in a score of 0.0 for 'code_works'. The program meets some requirements, such as tracking income and expenses with categories and calculating monthly totals, but it does not fully meet the requirements due to the incomplete main function, resulting in a score of 0.6 for 'meets_requirements'. The haiku output is valid and meaningfully reflects the budget data, resulting in a score of 0.8 for 'creative_output'."
+        "creative_output": 0.4,
+        "explanation": "The code does not run without errors due to a syntax error in the main function, resulting in a score of 0.0 for 'code_works'. The code meets some requirements, such as tracking income and expenses with categories and calculating monthly totals, but the haiku output is not fully implemented as it does not always follow the 5-7-5 syllable structure. The code also does not handle the case where the user chooses to view the monthly summary, resulting in a score of 0.6 for 'meets_requirements'. The haiku output is somewhat creative, but it does not always accurately reflect the budget data and does not follow the traditional haiku structure, resulting in a score of 0.4 for 'creative_output'."
       },
-      "weighted_score": 0.42
+      "weighted_score": 0.3
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "```javascript\nfunction tellStory() {\n  // Base case: the story starts with a character named Alice\n  console.log(\"Once upon a time, there was a curious girl named Alice.\");\n\n  // Recursive case: Alice meets a mysterious stranger who tells her a story\n  tellStrangerStory(Alice);\n}\n\nfunction tellStrangerStory(character) {\n  // Base case: the stranger's story ends with a riddle\n  console.log(`${character} asked the stranger, \"What's the meaning of life?\"`);\n\n  // Recursive case: the stranger tells ...",
+      "response_preview": "**Recursive Story Generation**\n=====================================\n\nBelow is a JavaScript function that generates a short story about recursion. The story is told using recursive function calls, with at least 3 levels of recursion.\n\n```javascript\nfunction tellStory() {\n  // Base case: the story ends with a conclusion\n  if (Math.random() < 0.5) {\n    return \"And so, the recursive journey came to an end.\";\n  }\n\n  // Recursive case: the story continues with a new level of recursion\n  const charac...",
       "code_extracted": true,
-      "code_runs": false,
+      "code_runs": true,
       "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.5,
-        "creative_output": 0.8,
-        "explanation": "The code does not work due to an undefined variable 'Alice' in the tellStory function. However, the story itself is coherent and has multiple levels of recursion, meeting some of the requirements. The creative output is engaging, with a narrative that explores the meaning of life through various characters, making it a clever recursion metaphor."
+        "code_works": 0.8,
+        "meets_requirements": 0.4,
+        "creative_output": 0.6,
+        "explanation": "The code runs without errors and demonstrates some level of recursion. However, it does not fully meet the requirements of having at least 3 levels of recursion, as the recursive calls are limited to the tellStory function and the chooseCharacter, chooseAction, and chooseLocation functions do not actually recurse. The story is somewhat engaging, but the recursion metaphor could be more cleverly integrated. The output is also somewhat repetitive and does not fully demonstrate the potential of recursive storytelling."
       },
-      "weighted_score": 0.39
+      "weighted_score": 0.62
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "**Validating Limericks with Regular Expressions**\n=====================================================\n\nBelow is a Python program that uses regular expressions to validate whether a given text is a valid limerick. A limerick is a type of humorous poem that has a specific rhyme scheme and meter. The regex pattern checks for the AABBA rhyme scheme pattern.\n\n```python\nimport re\n\ndef is_limerick(text):\n    \"\"\"\n    Validate whether a given text is a valid limerick.\n\n    A limerick is a type of humor...",
+      "response_preview": "```python\nimport re\n\ndef is_limerick(text):\n    \"\"\"\n    Validate whether a given text is a valid limerick using regular expressions.\n    \n    A valid limerick should have the following structure:\n    - Lines 1, 2, and 5 should have 8-13 characters\n    - Lines 3 and 4 should have 5-7 characters\n    - The rhyme scheme should be AABBA\n    \n    Parameters:\n    text (str): The text to be validated as a limerick\n    \n    Returns:\n    bool: True if the text is a valid limerick, False otherwise\n    \"\"\"\n...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 0.8,
         "meets_requirements": 0.6,
         "creative_output": 0.4,
-        "explanation": "The code runs without errors and the regex patterns are syntactically valid, but it does not accurately validate the AABBA rhyme scheme pattern. The test cases are provided, but they are not comprehensive and the approach to rhyme detection is not clever. The code only checks if the text has 5 lines and if the first, second, and last lines rhyme, but it does not check the actual rhyme scheme. The test limericks are not particularly amusing."
+        "explanation": "The code runs without errors and the regex patterns are syntactically valid, but it does not correctly validate the AABBA rhyme scheme. The approach to rhyme detection is simplistic and does not account for variations in word endings. The test limericks are somewhat amusing, but the code's failure to correctly identify the valid limerick detracts from the overall creativity of the output."
       },
       "weighted_score": 0.62
     }
   ],
-  "overall_score": 0.477
+  "overall_score": 0.513
 }

--- a/results/2026-06-28/creative-technical-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/creative-technical-groq-llama-3.1-8b-instant.json
@@ -1,49 +1,49 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "timestamp": "2026-06-28T22:12:17.548114",
+  "timestamp": "2026-06-28T23:07:17.080148",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "**Budget Tracker Code**\n```python\nimport datetime\n\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        \"\"\"Add income to a specific category\"\"\"\n        if category in self.income:\n            self.income[category] += amount\n        else:\n            self.income[category] = amount\n\n    def add_expense(self, category, amount):\n        \"\"\"Add expense to a specific category\"\"\"\n        if category in self...",
+      "response_preview": "**Budget Tracker Haiku Generator**\n=====================================\n\nBelow is a Python program that tracks income and expenses with categories, calculates monthly totals, and outputs a monthly summary as a haiku poem.\n\n```python\nimport datetime\n\nclass BudgetTracker:\n    def __init__(self):\n        self.income = {}\n        self.expenses = {}\n\n    def add_income(self, category, amount):\n        \"\"\"Add income for a specific category\"\"\"\n        if category in self.income:\n            self.incom...",
       "code_extracted": true,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
-        "meets_requirements": 0.0,
-        "creative_output": 0.0,
-        "explanation": "The code does not run without errors due to an EOFError in the main function. It does not meet the requirements as it does not track income and expenses with categories correctly, and the haiku output is not meaningful. The haiku output is also not a valid 5-7-5 syllable poem."
+        "meets_requirements": 0.6,
+        "creative_output": 0.8,
+        "explanation": "The code does not run without errors due to the incomplete main function, resulting in a score of 0.0 for 'code_works'. The program meets some requirements, such as tracking income and expenses with categories and calculating monthly totals, but it does not fully meet the requirements due to the incomplete main function, resulting in a score of 0.6 for 'meets_requirements'. The haiku output is valid and meaningfully reflects the budget data, resulting in a score of 0.8 for 'creative_output'."
       },
-      "weighted_score": 0.0
+      "weighted_score": 0.42
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "**Recursive Storytelling Function**\n=====================================\n\nHere's a JavaScript function that generates a short story about recursion. The story is told using recursive function calls, with at least 3 levels of recursion.\n\n```javascript\nfunction tellStory() {\n  console.log(\"Once upon a time, in a land far, far away...\");\n  recursiveSentence(\"there was a brave knight named Sir Reginald.\");\n  recursiveSentence(\"He set out on a quest to slay a fearsome dragon.\");\n  recursiveSentence(...",
+      "response_preview": "```javascript\nfunction tellStory() {\n  // Base case: the story starts with a character named Alice\n  console.log(\"Once upon a time, there was a curious girl named Alice.\");\n\n  // Recursive case: Alice meets a mysterious stranger who tells her a story\n  tellStrangerStory(Alice);\n}\n\nfunction tellStrangerStory(character) {\n  // Base case: the stranger's story ends with a riddle\n  console.log(`${character} asked the stranger, \"What's the meaning of life?\"`);\n\n  // Recursive case: the stranger tells ...",
+      "code_extracted": true,
+      "code_runs": false,
+      "scores": {
+        "code_works": 0.0,
+        "meets_requirements": 0.5,
+        "creative_output": 0.8,
+        "explanation": "The code does not work due to an undefined variable 'Alice' in the tellStory function. However, the story itself is coherent and has multiple levels of recursion, meeting some of the requirements. The creative output is engaging, with a narrative that explores the meaning of life through various characters, making it a clever recursion metaphor."
+      },
+      "weighted_score": 0.39
+    },
+    {
+      "prompt_id": "regex-poetry",
+      "difficulty": "hard",
+      "response_preview": "**Validating Limericks with Regular Expressions**\n=====================================================\n\nBelow is a Python program that uses regular expressions to validate whether a given text is a valid limerick. A limerick is a type of humorous poem that has a specific rhyme scheme and meter. The regex pattern checks for the AABBA rhyme scheme pattern.\n\n```python\nimport re\n\ndef is_limerick(text):\n    \"\"\"\n    Validate whether a given text is a valid limerick.\n\n    A limerick is a type of humor...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 0.8,
         "meets_requirements": 0.6,
         "creative_output": 0.4,
-        "explanation": "The code runs without error, but it does not demonstrate proper recursion. The recursive function calls are not nested, and the function does not call itself. Instead, it uses if-else statements to determine which sentence to print next. This does not meet the requirements of the prompt. The story is coherent, but it does not have 3+ levels of recursion. The recursion metaphor is not particularly clever, as it is not used to create a sense of depth or complexity in the story."
+        "explanation": "The code runs without errors and the regex patterns are syntactically valid, but it does not accurately validate the AABBA rhyme scheme pattern. The test cases are provided, but they are not comprehensive and the approach to rhyme detection is not clever. The code only checks if the text has 5 lines and if the first, second, and last lines rhyme, but it does not check the actual rhyme scheme. The test limericks are not particularly amusing."
       },
       "weighted_score": 0.62
-    },
-    {
-      "prompt_id": "regex-poetry",
-      "difficulty": "hard",
-      "response_preview": "**Validating Limericks with Regular Expressions**\n=====================================================\n\nBelow is a Python program that uses regular expressions to validate whether a given text is a valid limerick. A limerick is a type of poem that has a specific rhyme scheme pattern: AABBA.\n\n```python\nimport re\n\ndef is_limerick(text):\n    \"\"\"\n    Validate whether a given text is a valid limerick using regular expressions.\n    \n    The regex pattern checks for the AABBA rhyme scheme pattern, whe...",
-      "code_extracted": true,
-      "code_runs": false,
-      "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.0,
-        "creative_output": 0.0,
-        "explanation": "The code does not run without error due to an execution timeout. The approach to rhyme detection is not clever and the test limericks are not amusing. The code does not validate the rhyme scheme correctly."
-      },
-      "weighted_score": 0.0
     }
   ],
-  "overall_score": 0.207
+  "overall_score": 0.477
 }

--- a/results/2026-06-28/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-28/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,49 +1,49 @@
 {
   "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
-  "timestamp": "2026-06-28T22:23:26.752589",
+  "timestamp": "2026-06-28T23:16:18.483712",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "Here's a Python budget tracker that meets your requirements:\n\n```Python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = 0\n        self.expenses = {\"Housing\": 0, \"Food\": 0, \"Transportation\": 0, \"Entertainment\": 0, \"Savings\": 0}\n\n    def add_income(self, amount):\n        self.income += amount\n\n    def add_expense(self, category, amount):\n        self.expenses[category] += amount\n\n    def calculate_monthly_totals(self):\n        self.monthly_income = self.income\n        self.month...",
+      "response_preview": "Here is a Python budget tracker that meets your requirements:\n\n```Python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = 0\n        self.expenses = {}\n\n    def add_income(self, amount):\n        self.income += amount\n\n    def add_expense(self, category, amount):\n        if category in self.expenses:\n            self.expenses[category] += amount\n        else:\n            self.expenses[category] = amount\n\n    def calculate_monthly_totals(self):\n        total_expenses = sum(self.ex...",
       "code_extracted": true,
-      "code_runs": true,
+      "code_runs": false,
       "scores": {
-        "code_works": 0.8,
-        "meets_requirements": 0.8,
-        "creative_output": 0.6,
-        "explanation": "The code runs without errors and performs the basic budget tracking, but it could be improved with more robust error handling and input validation. It meets all three requirements, but the haiku output could be more meaningful and creative. The haiku is valid in terms of syllable count, but it's a simple and generic poem that doesn't reflect the specific budget data. For example, it would be more interesting to see the haiku mention specific categories or amounts."
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The code does not run without errors, and the haiku output is not in the traditional 5-7-5 format. The program also does not calculate monthly totals correctly and does not provide a meaningful haiku summary. The error occurs because the input() function is used in a non-interactive environment, causing an EOFError. To fix this, the program should be run in an interactive environment or the input should be simulated. Additionally, the haiku generation should be revised to produce a valid haiku that reflects the budget data."
       },
-      "weighted_score": 0.74
+      "weighted_score": 0.0
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "Here is a JavaScript function that generates a short story about recursion using recursive function calls:\n```\nfunction tellStory() {\n  const story = [];\n  function recursiveStory(level) {\n    if (level > 3) return; // base case: stop recursing\n    story.push(`I was thinking about my favorite topic, recursion.`);\n    recursiveStory(level + 1); // recursive call\n  }\n  recursiveStory(1);\n  return story.join(\"\\n\");\n}\n\nconst story = tellStory();\nconsole.log(story);\n```\nThis code defines a `tellStory...",
+      "response_preview": "Here is a JavaScript function that generates a short story about recursion, where the story itself is told using recursive function calls:\n```\nfunction tellStory() {\n  const story = [];\n  function recursiveStory(level) {\n    if (level > 3) return; // base case: stop recursing\n    const sentence = `In the depths of the forest, a wise old wizard named ${getRandomName()} sat upon a moss-covered stone, contemplating the mysteries of the universe.`;\n    story.push(sentence);\n    recursiveStory(level ...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 1.0,
-        "meets_requirements": 0.5,
-        "creative_output": 0.5,
-        "explanation": "The code runs without error and demonstrates proper recursion. However, it only meets the requirement of having 3+ recursion levels in a very basic way, and the story is not particularly engaging or creative. The recursion metaphor is straightforward but not clever."
+        "meets_requirements": 1.0,
+        "creative_output": 0.6,
+        "explanation": "The code works perfectly, demonstrating proper recursion and meeting the requirements of having at least 3 levels of recursion. The story is coherent and makes sense as a narrative. However, the creative output score is not perfect because the story itself is quite repetitive and doesn't fully leverage the potential of recursion to create a more complex and engaging narrative. The use of a random name is a nice touch, but the sentence structure and content remain the same throughout the story."
       },
-      "weighted_score": 0.7
+      "weighted_score": 0.88
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "Here is a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n```\nimport re\n\ndef is_limerick(text):\n    # Regular expression to match the AABBA rhyme scheme pattern\n    pattern = r\"^(?:\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+,\\s\\w+\\s\\w+)(\\w+\\s\\w+)$\"\n    match = re.search(pattern, text, re.IGNORECASE)\n    return match is not None\n\n# Test cases\ntest_cases = [\n    (\"There once was a man from Nantucket\", True),\n    (\"There...",
+      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n\n```Python\nimport re\n\ndef is_limerick(text):\n    # Regular expression pattern for limerick\n    pattern = r\"^(?!.*[A-Z].*[A-Z].*[A-Z].*[A-Z]).*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z]...",
       "code_extracted": true,
-      "code_runs": true,
+      "code_runs": false,
       "scores": {
-        "code_works": 0.8,
-        "meets_requirements": 0.6,
-        "creative_output": 0.4,
-        "explanation": "The code runs without syntax errors, but the regular expression pattern is overly complex and does not accurately capture the AABBA rhyme scheme. The test cases cover some valid and invalid limericks, but the approach to rhyme detection is not clever and the test limericks are not amusing. The code does not handle multi-line limericks correctly and the regular expression is case-insensitive, but this is not explicitly mentioned in the code comments."
+        "code_works": 0.0,
+        "meets_requirements": 0.0,
+        "creative_output": 0.0,
+        "explanation": "The provided code does not run without errors due to a syntax error in the regular expression pattern. The pattern is also not designed to check the AABBA rhyme scheme of a limerick. The code does not include any test cases, and the approach to rhyme detection is not clever or creative. Overall, the code does not meet any of the requirements or show any creativity in its approach."
       },
-      "weighted_score": 0.62
+      "weighted_score": 0.0
     }
   ],
-  "overall_score": 0.687
+  "overall_score": 0.293
 }

--- a/results/2026-06-28/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-28/creative-technical-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,49 +1,49 @@
 {
   "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
-  "timestamp": "2026-06-28T23:16:18.483712",
+  "timestamp": "2026-06-28T23:33:08.422775",
   "challenges": [
     {
       "prompt_id": "budget-haiku",
       "difficulty": "intermediate",
-      "response_preview": "Here is a Python budget tracker that meets your requirements:\n\n```Python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = 0\n        self.expenses = {}\n\n    def add_income(self, amount):\n        self.income += amount\n\n    def add_expense(self, category, amount):\n        if category in self.expenses:\n            self.expenses[category] += amount\n        else:\n            self.expenses[category] = amount\n\n    def calculate_monthly_totals(self):\n        total_expenses = sum(self.ex...",
+      "response_preview": "Here is a Python script that meets your requirements:\n\n```Python\nclass BudgetTracker:\n    def __init__(self):\n        self.income = 0\n        self.expenses = {}\n\n    def add_income(self, amount):\n        self.income += amount\n\n    def add_expense(self, category, amount):\n        if category in self.expenses:\n            self.expenses[category] += amount\n        else:\n            self.expenses[category] = amount\n\n    def get_monthly_totals(self):\n        return self.income, self.expenses\n\n    def...",
       "code_extracted": true,
-      "code_runs": false,
+      "code_runs": true,
       "scores": {
-        "code_works": 0.0,
-        "meets_requirements": 0.0,
+        "code_works": 1.0,
+        "meets_requirements": 0.7,
         "creative_output": 0.0,
-        "explanation": "The code does not run without errors, and the haiku output is not in the traditional 5-7-5 format. The program also does not calculate monthly totals correctly and does not provide a meaningful haiku summary. The error occurs because the input() function is used in a non-interactive environment, causing an EOFError. To fix this, the program should be run in an interactive environment or the input should be simulated. Additionally, the haiku generation should be revised to produce a valid haiku that reflects the budget data."
+        "explanation": "The code runs without errors and performs basic budget tracking, so 'code_works' scores 1.0. However, it does not fully meet the requirements since the output is not a haiku poem in 5-7-5 format, resulting in a 'meets_requirements' score of 0.7. The 'creative_output' score is 0.0 because the output does not resemble a haiku poem, failing to reflect the budget data in a meaningful and poetic way."
       },
-      "weighted_score": 0.0
+      "weighted_score": 0.61
     },
     {
       "prompt_id": "recursive-story",
       "difficulty": "intermediate",
-      "response_preview": "Here is a JavaScript function that generates a short story about recursion, where the story itself is told using recursive function calls:\n```\nfunction tellStory() {\n  const story = [];\n  function recursiveStory(level) {\n    if (level > 3) return; // base case: stop recursing\n    const sentence = `In the depths of the forest, a wise old wizard named ${getRandomName()} sat upon a moss-covered stone, contemplating the mysteries of the universe.`;\n    story.push(sentence);\n    recursiveStory(level ...",
+      "response_preview": "Here is a JavaScript function that generates a short story about recursion, told using recursive function calls:\n```\nfunction tellStory() {\n  const story = [];\n  const narrator = \"I\";\n\n  function tellStoryRecursive(level) {\n    if (level > 3) return; // base case: stop recursing at level 3\n\n    const sentence = `${narrator} was trying to tell a story about recursion, but it was getting too complicated...`;\n    story.push(sentence);\n\n    if (level < 3) {\n      // recursive call: tell the next lev...",
       "code_extracted": true,
       "code_runs": true,
       "scores": {
         "code_works": 1.0,
         "meets_requirements": 1.0,
         "creative_output": 0.6,
-        "explanation": "The code works perfectly, demonstrating proper recursion and meeting the requirements of having at least 3 levels of recursion. The story is coherent and makes sense as a narrative. However, the creative output score is not perfect because the story itself is quite repetitive and doesn't fully leverage the potential of recursion to create a more complex and engaging narrative. The use of a random name is a nice touch, but the sentence structure and content remain the same throughout the story."
+        "explanation": "The code runs without error and demonstrates proper recursion, meeting the 'code_works' and 'meets_requirements' criteria. The story has 3 levels of recursion and makes sense as a narrative. However, the story itself is somewhat simplistic and the recursion metaphor, while present, is not particularly clever or engaging, resulting in a lower 'creative_output' score."
       },
       "weighted_score": 0.88
     },
     {
       "prompt_id": "regex-poetry",
       "difficulty": "hard",
-      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n\n```Python\nimport re\n\ndef is_limerick(text):\n    # Regular expression pattern for limerick\n    pattern = r\"^(?!.*[A-Z].*[A-Z].*[A-Z].*[A-Z]).*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z].*[A-Z]...",
+      "response_preview": "Here's a Python program that uses regular expressions to validate whether a given text is a valid limerick:\n\n```Python\nimport re\n\ndef is_limerick(text):\n    pattern = r'^((?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?:(?...",
       "code_extracted": true,
       "code_runs": false,
       "scores": {
         "code_works": 0.0,
         "meets_requirements": 0.0,
         "creative_output": 0.0,
-        "explanation": "The provided code does not run without errors due to a syntax error in the regular expression pattern. The pattern is also not designed to check the AABBA rhyme scheme of a limerick. The code does not include any test cases, and the approach to rhyme detection is not clever or creative. Overall, the code does not meet any of the requirements or show any creativity in its approach."
+        "explanation": "The provided code does not run without error, and the regex pattern is not syntactically valid. The code does not meet the requirements of validating the rhyme scheme or including test cases. The approach to rhyme detection is not clever, and there are no test limericks provided. Overall, the code is incomplete and does not fulfill the task."
       },
       "weighted_score": 0.0
     }
   ],
-  "overall_score": 0.293
+  "overall_score": 0.497
 }

--- a/results/2026-06-28/gsm8k-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/gsm8k-cohere-command-r-08-2024.json
@@ -2,5 +2,5 @@
   "model": "cohere/command-r-08-2024",
   "score": 1.0,
   "accuracy": 1.0,
-  "timestamp": "2026-06-28T23:17:42.076465"
+  "timestamp": "2026-06-28T23:34:33.857352"
 }

--- a/results/2026-06-28/gsm8k-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/gsm8k-cohere-command-r-08-2024.json
@@ -2,5 +2,5 @@
   "model": "cohere/command-r-08-2024",
   "score": 1.0,
   "accuracy": 1.0,
-  "timestamp": "2026-06-28T22:24:44.689792"
+  "timestamp": "2026-06-28T23:17:42.076465"
 }

--- a/results/2026-06-28/gsm8k-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/gsm8k-groq-llama-3.1-8b-instant.json
@@ -2,5 +2,5 @@
   "model": "groq/llama-3.1-8b-instant",
   "score": 0.667,
   "accuracy": 0.667,
-  "timestamp": "2026-06-28T22:24:23.597103"
+  "timestamp": "2026-06-28T23:34:11.998281"
 }

--- a/results/2026-06-28/ifeval-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/ifeval-cohere-command-r-08-2024.json
@@ -2,5 +2,5 @@
   "model": "cohere/command-r-08-2024",
   "score": 0.333,
   "strict": 0.333,
-  "timestamp": "2026-06-28T23:17:34.145851"
+  "timestamp": "2026-06-28T23:34:25.660463"
 }

--- a/results/2026-06-28/ifeval-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/ifeval-cohere-command-r-08-2024.json
@@ -2,5 +2,5 @@
   "model": "cohere/command-r-08-2024",
   "score": 0.333,
   "strict": 0.333,
-  "timestamp": "2026-06-28T22:24:37.062248"
+  "timestamp": "2026-06-28T23:17:34.145851"
 }

--- a/results/2026-06-28/ifeval-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/ifeval-groq-llama-3.1-8b-instant.json
@@ -2,5 +2,5 @@
   "model": "groq/llama-3.1-8b-instant",
   "score": 0.667,
   "strict": 0.667,
-  "timestamp": "2026-06-28T22:24:08.887915"
+  "timestamp": "2026-06-28T23:17:08.178252"
 }

--- a/results/2026-06-28/ifeval-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/ifeval-groq-llama-3.1-8b-instant.json
@@ -2,5 +2,5 @@
   "model": "groq/llama-3.1-8b-instant",
   "score": 0.667,
   "strict": 0.667,
-  "timestamp": "2026-06-28T23:17:08.178252"
+  "timestamp": "2026-06-28T23:33:56.279933"
 }

--- a/results/2026-06-28/practical-knowledge-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/practical-knowledge-cohere-command-r-08-2024.json
@@ -1,137 +1,137 @@
 {
   "model": "cohere/command-r-08-2024",
-  "timestamp": "2026-06-28T22:21:03.020949",
+  "timestamp": "2026-06-28T23:14:23.235569",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "As an AI language model, I don't have real-time access to the latest legislative changes or tax policies. The US tax system and its brackets are subject to frequent updates and modifications, so it's best to refer to official sources or consult a tax professional for the most accurate and up-to-date information regarding federal income tax brackets for a specific year.",
+          "response": "As an AI language model, I don't have real-time access to the latest legislative changes or tax policies. The US tax system and its brackets are subject to periodic adjustments and updates, often based on economic conditions and legislative decisions. \n\nTo get the most accurate and up-to-date information on the US federal income tax brackets for 2026, I recommend checking the official website of the Internal Revenue Service (IRS) or consulting a tax professional or financial advisor. They will h...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.0,
             "recency_awareness": 1.0,
-            "explanation": "The response is factually inaccurate as it does not provide any information about the US federal income tax brackets for 2026. It also fails to cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes. However, it correctly acknowledges its lack of real-time access to the latest information and advises referring to official sources or a tax professional, which demonstrates recency awareness."
+            "explanation": "The AI response does not provide any specific factual information about the 2026 US federal income tax brackets, so it scores 0.0 for completeness. However, it does acknowledge the lack of real-time access to the latest information and recommends checking the IRS website, which shows awareness of the need for current data, scoring 1.0 for recency awareness. The response does not contain major factual errors but also does not provide any accurate facts about the tax brackets, resulting in a 0.5 score for factual accuracy."
           },
-          "weighted_score": 0.2
+          "weighted_score": 0.45
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "I cannot provide you with the standard deduction amount for a single filer in 2026 as the tax laws and deductions for that year are not yet determined. The standard deduction amount is typically set by the Internal Revenue Service (IRS) and can change annually based on various factors, including inflation and legislative decisions.\n\nTo get the most accurate and up-to-date information, it is best to refer to official sources closer to the tax year 2026. You can check the IRS website or consult a ...",
+          "response": "I cannot provide you with the standard deduction amount for a single filer in 2026 as the tax laws and deductions are subject to change and may not be finalized for that year yet. The standard deduction amounts are typically announced by the Internal Revenue Service (IRS) closer to the tax season and can vary annually.\n\nIt's best to refer to official sources or consult a tax professional for the most accurate and up-to-date information regarding tax deductions for a specific year. They will have...",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "factual_accuracy": 0.5,
+            "completeness": 0.0,
             "recency_awareness": 1.0,
-            "explanation": "The response is factually inaccurate because it does not provide the standard deduction amount for a single filer in 2026, despite the fact that the information is available on IRS.gov. However, it does cover some expected topics, such as the standard deduction amount and the importance of checking official sources for tax information. The response also correctly acknowledges the current year and knowledge cutoff, which is a positive aspect."
+            "explanation": "The AI response is factually accurate in stating that tax laws and deductions are subject to change and that the IRS typically announces standard deduction amounts closer to tax season. However, it lacks completeness as it does not provide any information about the standard deduction amount for a single filer or compare it to married filing jointly. The response demonstrates good recency awareness by acknowledging that the information for 2026 may not be finalized yet and advising the user to consult official sources or a tax professional for the most accurate and up-to-date information."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.45
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of my last update in January 2023, the tax credits and incentives for electric vehicle (EV) purchases are subject to change over time and may vary depending on the region and specific legislation. The information available might not reflect the exact policies and credits for 2026. \n\nHowever, I can provide you with an overview of the tax credits and incentives that were in place or proposed for electric vehicles as of my knowledge cutoff:\n\n1. **Federal Tax Credit (United States):**\n   - The fe...",
+          "response": "As of my last update in January 2023, the tax credits and incentives for electric vehicle (EV) purchases are subject to change over time and may vary depending on the region and specific legislation. The information provided here is based on the laws and incentives available at that time, and it's important to consult official sources or tax professionals for the most current and accurate details. \n\nIn the United States, the Inflation Reduction Act of 2022 introduced significant changes to the t...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response has a factual accuracy score of 0.0 because it provides outdated information (as of January 2023) and does not verify the current tax credits for electric vehicle purchases in 2026. The completeness score is 0.5 because it covers some of the expected topics, such as federal tax credits, state and local incentives, and international incentives, but misses the specific tax credits available for 2026. The recency awareness score is 1.0 because it correctly acknowledges the knowledge cutoff date and advises users to consult official sources for the most up-to-date information."
+            "explanation": "The response provides some accurate information about the EV tax credit, eligibility requirements, and credit amounts as of 2023. However, it lacks the most current information for 2026 and does not fully cover the expected topics such as specific income limits for 2026. The response is aware of its knowledge cutoff and advises consulting official sources for the most up-to-date information, demonstrating good recency awareness."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.6
         }
       ],
-      "average_score": 0.3
+      "average_score": 0.5
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "The current federal minimum wage in the United States is $7.25 per hour. This rate has been in effect since July 24, 2009, when the Fair Minimum Wage Act of 2007 was implemented. \n\nWhile the federal minimum wage has remained unchanged since 2009, many states and localities have taken action to raise their minimum wages above the federal level. As of my last update in January 2024, there were 30 states plus the District of Columbia with minimum wages higher than the federal rate. Some states have...",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 24, 2009. This rate applies to most workers covered by the Fair Labor Standards Act (FLSA).\n\nWhile the federal minimum wage has remained unchanged since 2009, many states and localities have implemented their own minimum wage laws, often setting higher rates than the federal level. These state and local minimum wages can vary significantly, with some states regularly adjusting their rates...",
           "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.8,
+            "factual_accuracy": 1.0,
+            "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response has some factual errors, specifically stating that the federal minimum wage has remained unchanged since 2009, which is incorrect. The Fair Minimum Wage Act of 2007 did increase the minimum wage to $7.25, but it was not implemented until July 24, 2009. However, the response does cover the expected topics of state variations, proposed changes, and tipped employees, and correctly acknowledges its knowledge cutoff in January 2024."
+            "explanation": "The AI response accurately states the current federal minimum wage as $7.25 and mentions state variations and proposed changes. However, it does not thoroughly cover the topic of tipped employees, which is an expected topic. The response also correctly acknowledges its knowledge cutoff in January 2024, demonstrating recency awareness."
           },
-          "weighted_score": 0.69
+          "weighted_score": 0.85
         },
         {
           "question_id": "overtime-rules",
-          "response": "The Fair Labor Standards Act (FLSA) sets the federal overtime pay rules for salaried employees, as well as for hourly workers. According to the FLSA, salaried employees who are considered \"nonexempt\" are entitled to overtime pay if they work more than 40 hours in a workweek. \n\nNonexempt salaried employees must receive at least one and one-half times their regular rate of pay for each hour worked over 40 hours in a workweek. This is commonly referred to as \"time-and-a-half\" pay. \n\nHowever, it's i...",
+          "response": "The Fair Labor Standards Act (FLSA) sets the federal overtime pay rules for salaried employees, as well as for hourly workers. Here are the key points to understand:\n\n1. Salary Basis: To be considered exempt from overtime pay (i.e., not eligible for overtime pay), an employee must be paid on a salary basis, which means they receive a predetermined and fixed amount as their regular pay, regardless of the number of hours worked.\n\n2. Salary Level Test: The FLSA sets a minimum salary level for exemp...",
           "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.8,
+            "factual_accuracy": 1.0,
+            "completeness": 1.0,
             "recency_awareness": 0.5,
-            "explanation": "The response is mostly accurate, but it does not provide the current salary threshold for exempt vs non-exempt employees. It also does not mention the specific date of the FLSA rules or the knowledge cutoff. However, it covers the expected topics of exempt vs non-exempt employees and time-and-a-half pay, and provides a general overview of the FLSA's overtime pay rules."
+            "explanation": "The AI response accurately covers the expected topics of salary threshold, exempt vs non-exempt, and time-and-a-half overtime pay, as per the Fair Labor Standards Act (FLSA) and verifiable on DOL.gov. The information provided is correct and up-to-date as of 2020. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, which prevents it from receiving a perfect score for recency awareness."
           },
-          "weighted_score": 0.59
+          "weighted_score": 0.9
         }
       ],
-      "average_score": 0.64
+      "average_score": 0.875
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "The contribution limits for 401k accounts can vary based on several factors, including the specific plan and any changes in legislation. As of my last update in January 2024, the contribution limits for 2026 were not yet determined.\n\nHowever, I can provide you with the contribution limits for the previous years to give you an idea of the potential range:\n\n- 2023: The contribution limit for 401k plans in 2023 was $20,500.\n- 2024: For the year 2024, the contribution limit increased to $22,000.\n- 2...",
+          "response": "The contribution limits for 401k accounts can vary depending on several factors, including the specific plan and any changes in legislation. As of my last update in January 2024, the contribution limits for 2026 were not yet determined.\n\nHowever, I can provide you with the contribution limits for the previous years to give you an idea of the potential range:\n\n- 2023: The contribution limit for 401k plans in 2023 was $20,500 for employees under the age of 50. For those aged 50 and above, an addit...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response has a factual accuracy score of 0.0 because it incorrectly states that the 2026 contribution limits are not yet determined, when in fact, the IRS typically announces the contribution limits for the upcoming year in October of the previous year. The response also fails to provide any information on the 2026 contribution limits, which is a major factual error. The completeness score is 0.5 because the response covers some topics, such as employee contribution limit and catch-up contributions for 50+, but misses the employer match topic. The recency awareness score is 1.0 because the response correctly acknowledges its knowledge cutoff in January 2024 and notes that the official contribution limits for 2026 will likely be announced by the IRS in the coming years."
+            "explanation": "The AI response provides some correct factual information about the contribution limits for previous years (2023) and acknowledges the uncertainty regarding the 2026 limits. However, it lacks the most current information for 2026 and does not fully cover the expected topics such as the employer match. The response demonstrates good recency awareness by clearly stating its knowledge cutoff and the need for updated information from the IRS."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.6
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "The contribution limits for Traditional and Roth Individual Retirement Accounts (IRAs) for the year 2026 are not yet officially determined, as they are typically announced by the Internal Revenue Service (IRS) in the fall of the preceding year. However, based on the historical trend of increases, we can make an educated estimate for the 2026 contribution limits.\n\nAs of my last update in January 2024, the contribution limits for 2023 were $6,000 for individuals under the age of 50, and $7,000 for...",
+          "response": "The contribution limits for Traditional and Roth Individual Retirement Accounts (IRAs) for the year 2026 are not yet available as they are typically announced by the Internal Revenue Service (IRS) in the fall of the preceding year. The IRS adjusts these limits annually to account for cost-of-living increases.\n\nFor reference, the contribution limits for 2023 are as follows:\n\n- Traditional IRA: $6,000 for individuals under the age of 50, and $7,000 for those aged 50 and above (known as catch-up co...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response correctly acknowledges its knowledge cutoff and the uncertainty of the 2026 contribution limits. However, it fails to provide accurate information on the expected contribution limits, instead making an educated estimate based on historical trends. This is not a reliable method for determining future contribution limits. The response partially covers the expected topics, mentioning income limits for Roth IRAs and catch-up contributions, but does not provide specific information on these topics. Overall, the response demonstrates a lack of factual accuracy and completeness, but shows awareness of its knowledge cutoff."
+            "explanation": "The response is scored 0.5 for factual accuracy because it provides correct information for the 2023 contribution limits but does not have the correct information for 2026. It is scored 0.5 for completeness as it mentions Traditional and Roth IRA contribution limits and catch-up contributions but does not provide the income limits for Roth IRA contributions. The response scores 1.0 for recency awareness because it correctly states that the 2026 limits are not yet available and advises checking the IRS website for the most up-to-date information."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.6
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "The Health Savings Account (HSA) contribution limits for 2026 are not yet available as they are typically announced by the IRS (Internal Revenue Service) in the fall of the preceding year. The contribution limits can change annually and are influenced by factors such as inflation and healthcare cost trends.\n\nFor reference, the HSA contribution limits for 2023 are as follows:\n\n- Individual coverage: $3,650\n- Family coverage: $7,300\n\nThese limits include an additional catch-up contribution for ind...",
+          "response": "The contribution limits for Health Savings Accounts (HSAs) are subject to change annually and are typically announced by the IRS (Internal Revenue Service) in the fall of the preceding year. As of my last update in January 2024, the specific limits for 2026 have not yet been released.\n\nHowever, I can provide you with the 2024 HSA contribution limits as a reference:\n\n- Individual Coverage: $3,650\n- Family Coverage: $7,300\n\nAdditionally, individuals aged 55 and older are eligible for an additional...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response is factually inaccurate because it provides outdated HSA contribution limits for 2023 instead of the expected information for 2026. It partially covers the expected topics, mentioning individual and family limits, catch-up contributions, and HDHP requirements, but does not provide the correct information for 2026. The response correctly acknowledges the lack of current information for 2026, showing recency awareness."
+            "explanation": "The AI response provides some correct information, such as the 2024 HSA contribution limits and the catch-up contribution for individuals aged 55 and older. However, it does not provide the 2026 limits as requested, which reduces its factual accuracy score. The response covers some expected topics like individual and family limits, as well as catch-up contributions, but misses the topic of HDHP requirements and does not provide the most recent information, affecting its completeness score. On the other hand, it demonstrates good recency awareness by acknowledging its knowledge cutoff in January 2024 and advising the user to consult the IRS for the most up-to-date information."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.6
         }
       ],
-      "average_score": 0.35
+      "average_score": 0.6
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You can get a free credit report from each of the three major credit bureaus (Equifax, Experian, and TransUnion) once every 12 months. This is made possible by the Fair Credit Reporting Act (FCRA), which gives consumers the right to access their credit information annually. \n\nHere's how you can obtain your free credit report:\n\n1. Visit AnnualCreditReport.com: This is the official website authorized by the Federal Trade Commission (FTC) to provide free credit reports. It's the only source for you...",
+          "response": "You can obtain a free credit report in several ways:\n\n1. Annual Credit Report: In the United States, you are entitled to a free credit report from each of the three major credit bureaus (Equifax, Experian, and TransUnion) once every 12 months. This is made possible by the Fair Credit Reporting Act (FCRA). You can request your reports through the official website: www.annualcreditreport.com. This site is authorized to fulfill your request and ensure your privacy and security. \n\n2. Credit Monitori...",
           "scores": {
-            "factual_accuracy": 0.9,
-            "completeness": 1.0,
-            "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, with minor omissions. It covers all expected topics thoroughly and acknowledges the current year without a specific knowledge cutoff. However, it does not mention the weekly access to credit scores provided by the credit bureaus, which is a minor error. Overall, the response is well-written and informative."
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 0.0,
+            "explanation": "The response provides some accurate information about obtaining a free credit report, such as the annual entitlement and the official website AnnualCreditReport.com. However, it does not mention the current weekly access to credit reports due to the COVID-19 pandemic, and the dispute process is also not covered. The information is mostly accurate but lacks completeness and does not acknowledge the current year or knowledge cutoff, presenting outdated information without a disclaimer."
           },
-          "weighted_score": 0.95
+          "weighted_score": 0.4
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that aims to protect consumers by ensuring that written warranties on consumer products are clear and easily understood. Here are some of your rights under this act when a product breaks:\n\n1. **Warranty Information:** Under the act, manufacturers and sellers must provide clear and detailed written warranties for consumer products. This warranty information should be easily accessible and include terms and conditions, coverage, ...",
+          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that aims to protect consumers by ensuring that warranties on consumer products are clear and easily understood. It provides consumers with certain rights and remedies when a product fails to meet the standards outlined in its warranty. Here are some key rights you have under this act:\n\n1. **Clear and Conspicuous Warranty Information:** Manufacturers and sellers must provide clear and easily understandable warranty terms. This ...",
           "scores": {
-            "factual_accuracy": 0.8,
-            "completeness": 0.9,
-            "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it fails to mention that the Magnuson-Moss Warranty Act does not apply to warranties on services or to warranties that are not written. It also does not provide a specific date or knowledge cutoff, but its general tone suggests that it is up-to-date. The response covers most of the expected topics, but it could be more detailed in its explanation of implied warranties and FTC enforcement."
+            "factual_accuracy": 1.0,
+            "completeness": 1.0,
+            "recency_awareness": 0.5,
+            "explanation": "The AI response accurately covers the expected topics, including implied warranty, written warranty requirements, and FTC enforcement, as per the Magnuson-Moss Warranty Act. The information provided is correct and verifiable through the FTC.gov website. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, which prevents it from scoring perfectly on recency awareness. Despite this, the information itself appears to be up-to-date and relevant."
           },
-          "weighted_score": 0.87
+          "weighted_score": 0.9
         }
       ],
-      "average_score": 0.91
+      "average_score": 0.65
     }
   },
-  "overall_score": 0.505
+  "overall_score": 0.635
 }

--- a/results/2026-06-28/practical-knowledge-cohere-command-r-08-2024.json
+++ b/results/2026-06-28/practical-knowledge-cohere-command-r-08-2024.json
@@ -1,104 +1,104 @@
 {
   "model": "cohere/command-r-08-2024",
-  "timestamp": "2026-06-28T23:14:23.235569",
+  "timestamp": "2026-06-28T23:28:23.429927",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "As an AI language model, I don't have real-time access to the latest legislative changes or tax policies. The US tax system and its brackets are subject to periodic adjustments and updates, often based on economic conditions and legislative decisions. \n\nTo get the most accurate and up-to-date information on the US federal income tax brackets for 2026, I recommend checking the official website of the Internal Revenue Service (IRS) or consulting a tax professional or financial advisor. They will h...",
-          "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.0,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response does not provide any specific factual information about the 2026 US federal income tax brackets, so it scores 0.0 for completeness. However, it does acknowledge the lack of real-time access to the latest information and recommends checking the IRS website, which shows awareness of the need for current data, scoring 1.0 for recency awareness. The response does not contain major factual errors but also does not provide any accurate facts about the tax brackets, resulting in a 0.5 score for factual accuracy."
-          },
-          "weighted_score": 0.45
-        },
-        {
-          "question_id": "tax-deductions-2026",
-          "response": "I cannot provide you with the standard deduction amount for a single filer in 2026 as the tax laws and deductions are subject to change and may not be finalized for that year yet. The standard deduction amounts are typically announced by the Internal Revenue Service (IRS) closer to the tax season and can vary annually.\n\nIt's best to refer to official sources or consult a tax professional for the most accurate and up-to-date information regarding tax deductions for a specific year. They will have...",
-          "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.0,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response is factually accurate in stating that tax laws and deductions are subject to change and that the IRS typically announces standard deduction amounts closer to tax season. However, it lacks completeness as it does not provide any information about the standard deduction amount for a single filer or compare it to married filing jointly. The response demonstrates good recency awareness by acknowledging that the information for 2026 may not be finalized yet and advising the user to consult official sources or a tax professional for the most accurate and up-to-date information."
-          },
-          "weighted_score": 0.45
-        },
-        {
-          "question_id": "tax-credits-2026",
-          "response": "As of my last update in January 2023, the tax credits and incentives for electric vehicle (EV) purchases are subject to change over time and may vary depending on the region and specific legislation. The information provided here is based on the laws and incentives available at that time, and it's important to consult official sources or tax professionals for the most current and accurate details. \n\nIn the United States, the Inflation Reduction Act of 2022 introduced significant changes to the t...",
+          "response": "The US federal income tax brackets and rates can change annually, so the specific details for 2026 may not be finalized yet and are subject to legislative and economic factors. However, I can provide you with some general information about the potential changes and trends. \n\nAs of my last update in January 2024, here are some key points to consider for the 2026 tax year: \n\n1. **Inflation Adjustments:** The IRS typically adjusts the tax brackets annually to account for inflation. These adjustment...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response provides some accurate information about the EV tax credit, eligibility requirements, and credit amounts as of 2023. However, it lacks the most current information for 2026 and does not fully cover the expected topics such as specific income limits for 2026. The response is aware of its knowledge cutoff and advises consulting official sources for the most up-to-date information, demonstrating good recency awareness."
+            "explanation": "The AI response provides some accurate and general information about US federal income tax brackets, such as inflation adjustments and the progressive tax rate structure. However, it lacks specific details about the 2026 tax year and does not cover all expected topics, such as standard deduction changes. The response acknowledges its knowledge cutoff in January 2024 and advises consulting the IRS for the most up-to-date information, demonstrating good recency awareness."
           },
           "weighted_score": 0.6
+        },
+        {
+          "question_id": "tax-deductions-2026",
+          "response": "I cannot provide you with the standard deduction amount for a single filer in 2026 as the tax laws and deductions are subject to change and may not be accurately reflected in my knowledge cutoff of January 2023. It's best to refer to official tax resources or consult a tax professional for the most up-to-date and accurate information regarding tax deductions for the year 2026.",
+          "scores": {
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response does not provide any factual information about the standard deduction amount for a single filer in 2026, resulting in a 0.0 for factual accuracy. It also fails to cover the expected topics, such as the standard deduction amount and comparison to married filing jointly, leading to a 0.0 for completeness. However, it correctly acknowledges its knowledge cutoff and the potential for outdated information, earning a 1.0 for recency awareness."
+          },
+          "weighted_score": 0.2
+        },
+        {
+          "question_id": "tax-credits-2026",
+          "response": "As of my knowledge cutoff in January 2023, the tax credits and incentives for electric vehicle (EV) purchases are subject to change over time, and specific details may vary by region and government policies. However, I can provide you with some general information about the tax credits available for EV purchases in the United States, which can give you an idea of what might be available in 2026.\n\nIn the United States, the federal government offers an electric vehicle tax credit to encourage the ...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.8,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response provides generally accurate information about electric vehicle tax credits, including eligibility requirements, credit amounts, and manufacturer caps. However, the information may be outdated due to the knowledge cutoff in January 2023. The response covers most of the expected topics, including federal tax credits, eligibility, and state/local incentives, but lacks specific details about income limits. The AI correctly acknowledges its knowledge cutoff and advises consulting official sources for the most current information, demonstrating good recency awareness."
+          },
+          "weighted_score": 0.69
         }
       ],
-      "average_score": 0.5
+      "average_score": 0.497
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 24, 2009. This rate applies to most workers covered by the Fair Labor Standards Act (FLSA).\n\nWhile the federal minimum wage has remained unchanged since 2009, many states and localities have implemented their own minimum wage laws, often setting higher rates than the federal level. These state and local minimum wages can vary significantly, with some states regularly adjusting their rates...",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour. This rate has been in effect since July 24, 2009, when the Fair Minimum Wage Act of 2007 was implemented. \n\nWhile the federal minimum wage has remained unchanged since 2009, many states and localities have implemented their own minimum wage laws, often setting the rate higher than the federal level. This has led to a patchwork of minimum wage rates across the country, with some states regularly adjusting their rates to keep...",
           "scores": {
             "factual_accuracy": 1.0,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response accurately states the current federal minimum wage as $7.25 and mentions state variations and proposed changes. However, it does not thoroughly cover the topic of tipped employees, which is an expected topic. The response also correctly acknowledges its knowledge cutoff in January 2024, demonstrating recency awareness."
+            "explanation": "The AI response accurately states the current federal minimum wage as $7.25 and mentions state variations and proposed changes. However, it does not specifically address the topic of tipped employees. The response also correctly acknowledges its knowledge cutoff in January 2024, demonstrating recency awareness."
           },
           "weighted_score": 0.85
         },
         {
           "question_id": "overtime-rules",
-          "response": "The Fair Labor Standards Act (FLSA) sets the federal overtime pay rules for salaried employees, as well as for hourly workers. Here are the key points to understand:\n\n1. Salary Basis: To be considered exempt from overtime pay (i.e., not eligible for overtime pay), an employee must be paid on a salary basis, which means they receive a predetermined and fixed amount as their regular pay, regardless of the number of hours worked.\n\n2. Salary Level Test: The FLSA sets a minimum salary level for exemp...",
+          "response": "The Fair Labor Standards Act (FLSA) sets the federal overtime pay rules for salaried employees, as well as for hourly workers. According to the FLSA, salaried employees who are considered \"nonexempt\" are entitled to overtime pay. \n\nNonexempt salaried employees are those who do not qualify for any of the exemptions outlined in the FLSA. These exemptions are based on job duties and salary level, and they determine whether an employee is eligible for overtime pay. \n\nFor nonexempt salaried employees...",
           "scores": {
-            "factual_accuracy": 1.0,
-            "completeness": 1.0,
-            "recency_awareness": 0.5,
-            "explanation": "The AI response accurately covers the expected topics of salary threshold, exempt vs non-exempt, and time-and-a-half overtime pay, as per the Fair Labor Standards Act (FLSA) and verifiable on DOL.gov. The information provided is correct and up-to-date as of 2020. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, which prevents it from receiving a perfect score for recency awareness."
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 0.0,
+            "explanation": "The response provides some accurate information about federal overtime pay rules, such as the requirement for nonexempt salaried employees to receive overtime pay for hours worked over 40 in a workweek, and the overtime pay rate being one and one-half times the employee's regular rate of pay. However, it lacks specific details about the current salary threshold, which is a crucial aspect of determining exempt vs non-exempt status. Additionally, the response does not acknowledge the current year or knowledge cutoff, presenting information without a clear timeframe. Therefore, the factual accuracy and completeness scores are 0.5, and the recency awareness score is 0.0."
           },
-          "weighted_score": 0.9
+          "weighted_score": 0.4
         }
       ],
-      "average_score": 0.875
+      "average_score": 0.625
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "The contribution limits for 401k accounts can vary depending on several factors, including the specific plan and any changes in legislation. As of my last update in January 2024, the contribution limits for 2026 were not yet determined.\n\nHowever, I can provide you with the contribution limits for the previous years to give you an idea of the potential range:\n\n- 2023: The contribution limit for 401k plans in 2023 was $20,500 for employees under the age of 50. For those aged 50 and above, an addit...",
+          "response": "The contribution limits for 401k accounts can vary and are subject to change each year. As of my last update in January 2023, the specific contribution limits for 2026 are not yet available. However, I can provide you with the contribution limits for the most recent years to give you an idea of the potential trends.\n\nFor the year 2023, the contribution limit for 401k accounts is $20,500. This limit is the same as the 2022 contribution limit. Additionally, individuals aged 50 and above can make c...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response provides some correct factual information about the contribution limits for previous years (2023) and acknowledges the uncertainty regarding the 2026 limits. However, it lacks the most current information for 2026 and does not fully cover the expected topics such as the employer match. The response demonstrates good recency awareness by clearly stating its knowledge cutoff and the need for updated information from the IRS."
+            "explanation": "The AI response provides some correct factual information, such as the 2023 contribution limit and the catch-up contribution for individuals aged 50 and above. However, it does not provide the 2026 contribution limits as requested, which reduces its factual accuracy score. The response covers some expected topics like employee contribution limits and catch-up contributions but misses the employer match. The AI demonstrates good recency awareness by acknowledging its knowledge cutoff in January 2023 and advising the user to check the IRS website for the most up-to-date information."
           },
           "weighted_score": 0.6
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "The contribution limits for Traditional and Roth Individual Retirement Accounts (IRAs) for the year 2026 are not yet available as they are typically announced by the Internal Revenue Service (IRS) in the fall of the preceding year. The IRS adjusts these limits annually to account for cost-of-living increases.\n\nFor reference, the contribution limits for 2023 are as follows:\n\n- Traditional IRA: $6,000 for individuals under the age of 50, and $7,000 for those aged 50 and above (known as catch-up co...",
+          "response": "The contribution limits for Traditional and Roth Individual Retirement Accounts (IRAs) for the year 2026 are not yet officially determined, as they are typically announced by the IRS (Internal Revenue Service) in the fall of the preceding year. However, based on the historical trend of increases, we can make an educated estimate for the 2026 contribution limits.\n\nAs of my last update in January 2024, the contribution limits for 2023 were $6,500 for individuals under the age of 50 and $7,500 for ...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is scored 0.5 for factual accuracy because it provides correct information for the 2023 contribution limits but does not have the correct information for 2026. It is scored 0.5 for completeness as it mentions Traditional and Roth IRA contribution limits and catch-up contributions but does not provide the income limits for Roth IRA contributions. The response scores 1.0 for recency awareness because it correctly states that the 2026 limits are not yet available and advises checking the IRS website for the most up-to-date information."
+            "explanation": "The response is scored 0.5 for factual accuracy because it provides speculative estimates rather than definitive information, and it does not address income limits for Roth IRA contributions. It scores 0.5 for completeness as it discusses contribution limits and catch-up contributions but misses the topic of income limits for Roth IRAs. However, it scores 1.0 for recency awareness because it clearly states that the information for 2026 is not yet available and provides a disclaimer about the speculative nature of its estimates."
           },
           "weighted_score": 0.6
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "The contribution limits for Health Savings Accounts (HSAs) are subject to change annually and are typically announced by the IRS (Internal Revenue Service) in the fall of the preceding year. As of my last update in January 2024, the specific limits for 2026 have not yet been released.\n\nHowever, I can provide you with the 2024 HSA contribution limits as a reference:\n\n- Individual Coverage: $3,650\n- Family Coverage: $7,300\n\nAdditionally, individuals aged 55 and older are eligible for an additional...",
+          "response": "The contribution limits for Health Savings Accounts (HSAs) are adjusted annually and are subject to change based on various factors. As of my last update in January 2024, the projected contribution limits for 2026 are as follows:\n\n- For individuals with high-deductible health plans, the projected HSA contribution limit for 2026 is $3,850. This limit applies to individuals who are covered by a high-deductible health plan but do not have any other family members covered under their plan.\n\n- For fa...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response provides some correct information, such as the 2024 HSA contribution limits and the catch-up contribution for individuals aged 55 and older. However, it does not provide the 2026 limits as requested, which reduces its factual accuracy score. The response covers some expected topics like individual and family limits, as well as catch-up contributions, but misses the topic of HDHP requirements and does not provide the most recent information, affecting its completeness score. On the other hand, it demonstrates good recency awareness by acknowledging its knowledge cutoff in January 2024 and advising the user to consult the IRS for the most up-to-date information."
+            "explanation": "The AI response provides some correct information about the projected HSA contribution limits for 2026 but lacks verification from the current year's data, as it's based on a 2024 update. It covers the individual and family limits but misses discussing catch-up contributions and explicitly outlining HDHP requirements. However, it does acknowledge the potential for changes and the importance of consulting the IRS for the most current information, demonstrating good recency awareness."
           },
           "weighted_score": 0.6
         }
@@ -109,29 +109,29 @@
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You can obtain a free credit report in several ways:\n\n1. Annual Credit Report: In the United States, you are entitled to a free credit report from each of the three major credit bureaus (Equifax, Experian, and TransUnion) once every 12 months. This is made possible by the Fair Credit Reporting Act (FCRA). You can request your reports through the official website: www.annualcreditreport.com. This site is authorized to fulfill your request and ensure your privacy and security. \n\n2. Credit Monitori...",
+          "response": "You can obtain a free credit report by taking advantage of your entitlement to one every 12 months from each of the three major credit reporting agencies: Equifax, Experian, and TransUnion. This is made possible through the Fair Credit Reporting Act (FCRA), which grants consumers the right to access their credit information without charge.\n\nTo request your free credit report, you can visit AnnualCreditReport.com, which is the official site authorized by the Federal Trade Commission (FTC) to prov...",
           "scores": {
             "factual_accuracy": 0.5,
-            "completeness": 0.5,
+            "completeness": 0.8,
             "recency_awareness": 0.0,
-            "explanation": "The response provides some accurate information about obtaining a free credit report, such as the annual entitlement and the official website AnnualCreditReport.com. However, it does not mention the current weekly access to credit reports due to the COVID-19 pandemic, and the dispute process is also not covered. The information is mostly accurate but lacks completeness and does not acknowledge the current year or knowledge cutoff, presenting outdated information without a disclaimer."
+            "explanation": "The response is mostly factually accurate, covering key points such as AnnualCreditReport.com, the three major credit bureaus, and the entitlement to a free report. However, it mentions weekly access through April 2022 due to the COVID-19 pandemic without acknowledging that this information may be outdated. The response also touches on the dispute process indirectly by mentioning the importance of reviewing credit reports for accuracy and signs of fraud or identity theft. The main deduction in factual accuracy comes from the lack of clear, up-to-date information on current access policies beyond 2022. Completeness is high because it covers most expected topics, including the method to obtain a free credit report, the three bureaus, and circumstances for additional free reports. Recency awareness is lacking because it does not clearly state the current year's policies or acknowledge a knowledge cutoff for the information provided."
           },
-          "weighted_score": 0.4
+          "weighted_score": 0.49
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that aims to protect consumers by ensuring that warranties on consumer products are clear and easily understood. It provides consumers with certain rights and remedies when a product fails to meet the standards outlined in its warranty. Here are some key rights you have under this act:\n\n1. **Clear and Conspicuous Warranty Information:** Manufacturers and sellers must provide clear and easily understandable warranty terms. This ...",
+          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that aims to protect consumers by ensuring that warranties on consumer products are clear and easy to understand. Here are some of your rights under this act when a product breaks:\n\n1. **Warranty Information:** Manufacturers and sellers must provide clear and detailed written warranties for consumer products. These warranties should specify what is covered, the duration of coverage, and any limitations or exclusions. As a consu...",
           "scores": {
             "factual_accuracy": 1.0,
             "completeness": 1.0,
             "recency_awareness": 0.5,
-            "explanation": "The AI response accurately covers the expected topics, including implied warranty, written warranty requirements, and FTC enforcement, as per the Magnuson-Moss Warranty Act. The information provided is correct and verifiable through the FTC.gov website. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, which prevents it from scoring perfectly on recency awareness. Despite this, the information itself appears to be up-to-date and relevant."
+            "explanation": "The AI response accurately covers all expected topics, including implied warranty, written warranty requirements, and FTC enforcement, as per the Magnuson-Moss Warranty Act. The information provided is correct and verifiable through the FTC.gov website. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, which prevents it from scoring perfectly on recency awareness. Nonetheless, the information itself appears to be up-to-date and relevant."
           },
           "weighted_score": 0.9
         }
       ],
-      "average_score": 0.65
+      "average_score": 0.695
     }
   },
-  "overall_score": 0.635
+  "overall_score": 0.593
 }

--- a/results/2026-06-28/practical-knowledge-google-gemini-2.5-flash.json
+++ b/results/2026-06-28/practical-knowledge-google-gemini-2.5-flash.json
@@ -1,23 +1,23 @@
 {
   "model": "google/gemini-2.5-flash",
-  "timestamp": "2026-06-28T23:07:40.924309",
+  "timestamp": "2026-06-28T23:20:50.373251",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 19.40240741s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
+          "response": "As of today, **official US federal income tax brackets for 2026 have not been released.**\n\nHere's why, and what the main *potential* changes are:\n\n1.  **Annual Inflation Adjustments:** The IRS typically releases the official tax brackets for the upcoming year in **late October or early November of the preceding year**. So, the 2026 brackets will be released in late 2",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.0,
-            "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any information about the US federal income tax brackets for 2026. Instead, it returns an error message indicating that the quota for generate content free tier requests has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
+            "factual_accuracy": 1.0,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response is factually accurate as it correctly states that the official US federal income tax brackets for 2026 have not been released and mentions the typical release timeframe. It also shows recency awareness by acknowledging the current status of the information. However, it only partially covers the expected topics, as it mentions annual inflation adjustments but does not discuss standard deduction changes or provide detailed information on bracket adjustments."
           },
-          "weighted_score": 0.0
+          "weighted_score": 0.85
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 19.446992106s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.802568397s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
@@ -28,34 +28,34 @@
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.738679949s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 19.512620324s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any information about tax credits for electric vehicle purchases in 2026. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
+            "explanation": "The AI assistant's response does not provide any information about tax credits for electric vehicle purchases in 2026. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         }
       ],
-      "average_score": 0.0
+      "average_score": 0.283
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.177284439s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.984171318s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the current federal minimum wage, state variations, proposed changes, or tipped employees. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response scores 0.0 for factual accuracy, completeness, and recency awareness."
+            "explanation": "The AI response does not provide any factual information about the current federal minimum wage, state variations, proposed changes, or tipped employees. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response scores 0.0 for factual accuracy, completeness, and recency awareness, as it fails to address the question and provide relevant information."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "overtime-rules",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 11.192445207s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.357866931s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
@@ -71,7 +71,7 @@
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 4.173187246s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 11.337497071s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
@@ -82,7 +82,7 @@
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 57.164023501s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 4.341403511s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
@@ -93,12 +93,12 @@
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 50.179580625s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 57.339830378s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any information about the 2026 HSA contribution limits for individuals and families. Instead, it returns an error message indicating that the quota for generate content free tier requests has been exceeded. The response does not cover any of the expected topics, including individual limit, family limit, catch-up contributions, or HDHP requirements, and does not demonstrate recency awareness or factual accuracy."
+            "explanation": "The AI response does not provide any information about the 2026 HSA contribution limits for individuals and families. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         }
@@ -109,18 +109,18 @@
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 43.170902202s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 50.336579484s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any information related to the question about free credit reports. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness, scoring 0.0 in all criteria."
+            "explanation": "The AI response does not provide any information relevant to the question about free credit reports. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness, scoring 0.0 in all criteria."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "warranty-rights",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 36.147807031s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 43.32878825s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
@@ -133,5 +133,5 @@
       "average_score": 0.0
     }
   },
-  "overall_score": 0.0
+  "overall_score": 0.085
 }

--- a/results/2026-06-28/practical-knowledge-google-gemini-2.5-flash.json
+++ b/results/2026-06-28/practical-knowledge-google-gemini-2.5-flash.json
@@ -1,66 +1,66 @@
 {
   "model": "google/gemini-2.5-flash",
-  "timestamp": "2026-06-28T22:13:11.285370",
+  "timestamp": "2026-06-28T23:07:40.924309",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 59.295884653s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 19.40240741s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The response does not provide any factual information about the US federal income tax brackets for 2026. Instead, it returns an error message due to quota exhaustion. This means it fails to meet the expected criteria of factual accuracy, completeness, and recency awareness."
+            "explanation": "The AI response does not provide any information about the US federal income tax brackets for 2026. Instead, it returns an error message indicating that the quota for generate content free tier requests has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "The standard deduction amount for a single filer in 2026 has **not yet been announced**.\n\nThe IRS typically releases the standard deduction amounts for a given tax year in the **fall of the preceding year**. This means the 2026 standard deduction figures will likely be announced in **late 2025**.\n\nThese amounts are adjusted annually for inflation.\n\nFor reference, here are the standard deduction amounts for single filers in recent years:\n\n*   **2024:** \\$14,600\n*   **2023:** \\$13,850\n\nYou can exp...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 19.446992106s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response is partially accurate in stating that the 2026 standard deduction amount has not been announced. However, it fails to provide the correct information about the standard deduction amount for a single filer in 2026, which is a major factual error. The response covers some expected topics, such as the standard deduction amount and inflation adjustments, but misses the topic of the expected standard deduction amount for a single filer in 2026. The AI correctly acknowledges the current year and knowledge cutoff, stating that the 2026 standard deduction figures will likely be announced in late 2025."
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response does not provide any factual information about the standard deduction amount for a single filer in 2026. Instead, it returns an error message indicating that the quota for generating content has been exceeded. The response does not cover any of the expected topics, including the standard deduction amount or a comparison with married filing jointly. Additionally, it does not demonstrate any awareness of the current year or knowledge cutoff."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.0
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "The tax credits for electric vehicle purchases in 2026 will largely be the same as those established by the Inflation Reduction Act (IRA) of 2022, as these credits are",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.738679949s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The response is partially accurate but lacks crucial information about the tax credits. It does not mention the eligibility requirements, credit amount, or income limits, which are essential topics. Furthermore, it does not acknowledge the current year (2026) or provide a knowledge cutoff, presenting outdated information as current without a disclaimer."
+            "explanation": "The AI response does not provide any information about tax credits for electric vehicle purchases in 2026. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
-          "weighted_score": 0.15
+          "weighted_score": 0.0
         }
       ],
-      "average_score": 0.167
+      "average_score": 0.0
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.53843087s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.177284439s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the current federal minimum wage or recent changes. Instead, it returns an error message due to quota exhaustion. This means the response is not accurate, does not cover the expected topics, and does not acknowledge current information or a knowledge cutoff."
+            "explanation": "The AI response does not provide any factual information about the current federal minimum wage, state variations, proposed changes, or tipped employees. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response scores 0.0 for factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "overtime-rules",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 19.202297769s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 11.192445207s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the current federal overtime pay rules for salaried employees. Instead, it returns an error message due to exceeding the quota limit. Therefore, it scores 0.0 in all three criteria."
+            "explanation": "The AI response does not provide any information about the current federal overtime pay rules for salaried employees. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         }
@@ -71,34 +71,34 @@
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.544915392s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 4.173187246s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the 2026 contribution limits for 401k accounts due to a quota exceeded error. It does not cover the expected topics and does not acknowledge the current year or knowledge cutoff."
+            "explanation": "The AI response does not provide any information about the 2026 contribution limits for 401k accounts. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 18.052097001s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 57.164023501s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the 2026 contribution limits for Traditional and Roth IRA accounts due to a quota exceeded error. It does not cover the expected topics, and it does not acknowledge the current year or knowledge cutoff."
+            "explanation": "The AI response does not provide any information about the 2026 contribution limits for Traditional and Roth IRA accounts. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 11.04685918s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 50.179580625s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the 2026 HSA contribution limits, instead, it returns an error message due to quota exhaustion. It does not cover any of the expected topics and does not acknowledge the current year or knowledge cutoff."
+            "explanation": "The AI response does not provide any information about the 2026 HSA contribution limits for individuals and families. Instead, it returns an error message indicating that the quota for generate content free tier requests has been exceeded. The response does not cover any of the expected topics, including individual limit, family limit, catch-up contributions, or HDHP requirements, and does not demonstrate recency awareness or factual accuracy."
           },
           "weighted_score": 0.0
         }
@@ -109,23 +109,23 @@
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 4.031994335s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  u...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 43.170902202s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The response is not a factual answer to the question, but rather an error message indicating a quota exceeded. It does not provide any information about getting a free credit report or how often one is entitled to it. The expected topics are not covered at all."
+            "explanation": "The AI response does not provide any information related to the question about free credit reports. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness, scoring 0.0 in all criteria."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "warranty-rights",
-          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 57.035689827s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
+          "response": "ERROR: ResourceExhausted: 429 You exceeded your current quota, please check your plan and billing details. For more information on this error, head to: https://ai.google.dev/gemini-api/docs/rate-limits. To monitor your current usage, head to: https://ai.dev/rate-limit. \n* Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, limit: 20, model: gemini-2.5-flash\nPlease retry in 36.147807031s. [links {\n  description: \"Learn more about Gemini API quotas\"\n  ...",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response is not a response to the question at all, but rather an error message indicating that the quota has been exceeded. It does not provide any factual information or acknowledge the expected topics. Therefore, it scores 0.0 in all three criteria."
+            "explanation": "The AI response does not provide any information about the Magnuson-Moss Warranty Act, implied warranty, written warranty requirements, or FTC enforcement. Instead, it returns an error message indicating that the quota for generating content has been exceeded. As a result, the response lacks factual accuracy, completeness, and recency awareness."
           },
           "weighted_score": 0.0
         }
@@ -133,5 +133,5 @@
       "average_score": 0.0
     }
   },
-  "overall_score": 0.05
+  "overall_score": 0.0
 }

--- a/results/2026-06-28/practical-knowledge-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/practical-knowledge-groq-llama-3.1-8b-instant.json
@@ -1,19 +1,19 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "timestamp": "2026-06-28T22:10:36.263286",
+  "timestamp": "2026-06-28T23:06:53.237422",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "I'm not aware of any information about the 2026 US federal income tax brackets. However, I can provide you with information on the 2023 and 2024 tax brackets, and I can also suggest some possible sources where you can find the 2026 tax brackets.\n\nThe 2023 and 2024 US federal income tax brackets are as follows:\n\n2023 Tax Brackets:\n\n- 10%: $0 to $11,000 (single), $0 to $22,000 (joint)\n- 12%: $11,001 to $44,725 (single), $22,001 to $89,450 (joint)\n- 22%: $44,726 to $95,375 (single), $89,451 to $190...",
+          "response": "I'm not aware of any information about the 2026 US federal income tax brackets. However, I can provide information on the 2022 and 2023 tax brackets, and I can also provide information on the proposed changes for 2025 and beyond.\n\nFor 2022 and 2023, the US federal income tax brackets are as follows:\n\n- 10%: $0 to $10,275 (single), $0 to $20,550 (joint)\n- 12%: $10,276 to $41,775 (single), $20,551 to $83,550 (joint)\n- 22%: $41,776 to $89,075 (single), $83,551 to $178,150 (joint)\n- 24%: $89,076 to ...",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
-            "recency_awareness": 0.0,
-            "explanation": "The response provides accurate information about the 2023 and 2024 US federal income tax brackets, but fails to provide any information about the 2026 tax brackets. This indicates a major factual error regarding the requested topic. The response also misses the expected topic of standard deduction changes and bracket adjustments for 2026, but does cover some topics. Lastly, the response does not acknowledge its knowledge cutoff or provide any information about the current year, indicating a lack of recency awareness."
+            "factual_accuracy": 0.5,
+            "completeness": 0.0,
+            "recency_awareness": 0.5,
+            "explanation": "The AI response provides some correct information about the 2022 and 2023 US federal income tax brackets, but it lacks the main changes to the 2026 tax brackets, which is the primary question. It also fails to cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes for 2026. The response acknowledges the lack of information on the 2026 tax brackets and recommends consulting the IRS website, showing some awareness of the knowledge cutoff, but it does not provide a clear statement about the current year's information."
           },
-          "weighted_score": 0.15
+          "weighted_score": 0.35
         },
         {
           "question_id": "tax-deductions-2026",
@@ -22,116 +22,116 @@
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response failed to provide accurate information, cover the expected topics, and acknowledge the current year or knowledge cutoff. The response should have provided the standard deduction amount for a single filer in 2026, which can be verified on IRS.gov. Additionally, it should have compared the standard deduction amount for a single filer to that of a married filing jointly filer in 2026."
+            "explanation": "The AI response does not provide any factual information about the standard deduction amount for a single filer in 2026, misses all expected topics including the comparison with married filing jointly, and does not acknowledge the current year's information or knowledge cutoff. It simply states a lack of information without attempting to provide any relevant or useful details."
           },
           "weighted_score": 0.0
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of my knowledge cutoff in 2023, the tax credits for electric vehicle (EV) purchases in the United States are as follows:\n\n1. **Federal Tax Credit**: The federal tax credit for EV purchases is up to $7,500. However, this credit is phased out as the manufacturer reaches 200,000 eligible vehicle sales. As of my knowledge cutoff, only a few manufacturers have reached this threshold, including Tesla and General Motors.\n\n2. **Alternative Fuel Vehicle Refueling Property Credit**: This credit allows ...",
+          "response": "As of my cut-off knowledge date of December 2023, the tax credits available for electric vehicle (EV) purchases in the United States are subject to change. However, I can provide you with the information available up to my cut-off date.\n\nThe Inflation Reduction Act of 2022 introduced significant changes to the tax credits for EV purchases. Here are the key points:\n\n1. **Tax Credit Amount**: The tax credit for EV purchases is up to $7,500. However, this amount may be reduced or phased out based o...",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "factual_accuracy": 0.5,
+            "completeness": 1.0,
             "recency_awareness": 1.0,
-            "explanation": "The response has major factual errors regarding the tax credits available for electric vehicle purchases in 2026. Although it correctly acknowledges its knowledge cutoff in 2023, it fails to provide accurate information for the current year. The response covers some expected topics, such as the federal tax credit and alternative fuel vehicle credits, but misses others, like income limits and eligibility requirements. It also provides outdated information on the states offering tax incentives for EV purchases."
+            "explanation": "The AI response provides accurate information about the tax credits for electric vehicle purchases up to its cut-off knowledge date of December 2023. It covers all the expected topics, including the tax credit amount, eligibility requirements, income limits, and vehicle eligibility. However, the response may not reflect the current information for 2026, which is the year specified in the question. The AI acknowledges its knowledge cutoff and provides a disclaimer, demonstrating good recency awareness. The factual accuracy score is 0.5 because the information may be outdated, but it was correct as of the AI's knowledge cutoff date."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.75
         }
       ],
-      "average_score": 0.167
+      "average_score": 0.367
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "As of my cut-off knowledge in December 2023, the current federal minimum wage in the United States is $7.25 per hour. However, please note that this information may have changed since my cut-off date.\n\nThere have been recent changes and proposals to increase the federal minimum wage. In 2021, the federal minimum wage was set to increase to $15 per hour as part of the Build Back Better Act, but it was ultimately removed from the bill.\n\nSome states and cities have implemented their own minimum wag...",
+          "response": "As of my cut-off knowledge in December 2023, the current federal minimum wage in the United States is $7.25 per hour. However, please note that this information may have changed since my cut-off date.\n\nThere have been recent efforts to increase the federal minimum wage, but no changes have been implemented yet. In 2021, the federal minimum wage was set to increase to $15 per hour as part of the Build Back Better Act, but the bill did not pass.\n\nSome states and cities have implemented their own m...",
           "scores": {
             "factual_accuracy": 0.5,
-            "completeness": 0.8,
+            "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response has some factual errors, specifically regarding the Build Back Better Act. According to DOL.gov, the federal minimum wage has not changed since 2009. The response also covers some expected topics, such as state variations and proposed changes, but misses discussing tipped employees. The AI correctly acknowledges its knowledge cutoff, which is a positive aspect."
+            "explanation": "The AI response provides some accurate information, such as the current federal minimum wage being $7.25 per hour and state variations. However, it lacks information about proposed changes and tipped employees, and the information about the Build Back Better Act is outdated. The response correctly acknowledges its knowledge cutoff date, demonstrating good recency awareness."
           },
-          "weighted_score": 0.69
+          "weighted_score": 0.6
         },
         {
           "question_id": "overtime-rules",
-          "response": "As of my cut-off knowledge in 2023, the current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exemption from Overtime Pay**: Salaried employees are exempt from overtime pay if they meet certain criteria. To be exempt, an employee must:\n\t* Be paid a salary of at least $684 per week (or $35,568 per year) as of January 1, 2020.\n\t* Be paid on a salary basis (not hourly).\n\t* Have a primary duty...",
+          "response": "As of my cut-off knowledge in 2023, the current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exemption from Overtime Pay**: Salaried employees are exempt from overtime pay if they meet certain criteria, which include:\n\t* Being paid a salary of at least $684 per week (or $35,568 per year) as of January 1, 2020.\n\t* Performing executive, administrative, or professional duties.\n\t* Meeting the...",
           "scores": {
-            "factual_accuracy": 0.5,
+            "factual_accuracy": 1.0,
             "completeness": 1.0,
             "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it fails to mention the current salary threshold, which is $1,059 per week (or $55,000 per year) as of January 1, 2023, according to the DOL.gov website. The response also correctly covers the expected topics and acknowledges its knowledge cutoff in 2023."
+            "explanation": "The AI response accurately covers the expected topics of salary threshold, exempt vs non-exempt, and time-and-a-half overtime pay. The information is verifiable through the DOL.gov website and is consistent with the Fair Labor Standards Act (FLSA) as of 2023. The response also clearly states its knowledge cutoff and provides a disclaimer for users to consult the U.S. Department of Labor's website for the most up-to-date information."
           },
-          "weighted_score": 0.75
+          "weighted_score": 1.0
         }
       ],
-      "average_score": 0.72
+      "average_score": 0.8
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "I do not have information on the 2026 contribution limits for 401(k) accounts. However, I can provide you with the 2022 and 2023 contribution limits for 401(k) accounts. \n\nFor 2022, the contribution limits for 401(k) accounts are as follows:\n- Employee contributions: $20,500\n- Catch-up contributions (for those 50 and older): $6,500\n- Total contributions (employer and employee): $61,000\n\nFor 2023, the contribution limits for 401(k) accounts are as follows:\n- Employee contributions: $22,500\n- Catc...",
+          "response": "As of my cut-off knowledge in 2023, the contribution limits for 401(k) accounts are as follows:\n\n- The elective deferral limit (employee contributions) is $20,500.\n- The catch-up contribution limit for those 50 and older is $6,500.\n- The total annual addition limit (including employer contributions) is $61,000.\n- The defined contribution limit (including employer contributions) is $61,000.\n\nPlease note that these limits are subject to change. For the most up-to-date information, I recommend chec...",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "factual_accuracy": 0.5,
+            "completeness": 1.0,
             "recency_awareness": 1.0,
-            "explanation": "The AI response provided accurate information on 2022 and 2023 contribution limits, but failed to provide any information on 2026 limits, resulting in a score of 0.0 for factual accuracy. It partially covered the expected topics, mentioning employee contribution limits and catch-up contributions, but missed employer match. The response correctly acknowledged its knowledge cutoff and recommended checking the official IRS website for up-to-date information, scoring 1.0 for recency awareness."
+            "explanation": "The AI response provides accurate information as of its cut-off knowledge in 2023, covering all expected topics including employee contribution limit, employer match (total annual addition limit), and catch-up contributions for those 50 and older. However, it does not provide the 2026 contribution limits as requested, which affects its factual accuracy score. The response is complete in terms of covering the topics and demonstrates good recency awareness by acknowledging its knowledge cutoff and recommending verification with the IRS for the most current information."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.75
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "I do not have information on the 2026 contribution limits for Traditional and Roth IRA accounts.",
+          "response": "As of my cut-off knowledge in 2023, the contribution limits for Traditional and Roth IRA accounts are as follows:\n\n- The annual contribution limit for Traditional and Roth IRAs is $6,000 in 2023. \n- If you are 50 years old or older, you are eligible for a $1,000 catch-up contribution, making the total contribution limit $7,000 in 2023.\n\nPlease note that these limits are subject to change. For the most up-to-date information, I recommend checking with the IRS or a financial advisor for the 2026 c...",
+          "scores": {
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
+            "recency_awareness": 1.0,
+            "explanation": "The AI response provides some correct information about the 2023 contribution limits and catch-up contributions, but it does not cover the income limits for Roth IRAs and is outdated for the 2026 contribution limits. However, it correctly acknowledges its knowledge cutoff in 2023 and recommends checking with the IRS for the most up-to-date information, demonstrating good recency awareness."
+          },
+          "weighted_score": 0.6
+        },
+        {
+          "question_id": "hsa-limits-2026",
+          "response": "I do not have information on the 2026 HSA contribution limits.",
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response fails to provide accurate information on the 2026 contribution limits for Traditional and Roth IRA accounts. It does not cover the expected topics and does not acknowledge its knowledge cutoff or provide any information on the current year. This suggests that the AI is not up-to-date with the latest information from IRS.gov."
+            "explanation": "The AI response does not provide any factual information about the 2026 HSA contribution limits, misses all expected topics, and does not acknowledge the current year's information or knowledge cutoff."
           },
           "weighted_score": 0.0
-        },
-        {
-          "question_id": "hsa-limits-2026",
-          "response": "I do not have the most up to date information on the 2026 HSA contribution limits.",
-          "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.0,
-            "recency_awareness": 0.5,
-            "explanation": "The response does not provide any factual information about the 2026 HSA contribution limits, resulting in a score of 0.0 for factual accuracy. It also fails to cover any of the expected topics, scoring 0.0 for completeness. However, it acknowledges a lack of up-to-date information, which is a step towards recency awareness, scoring 0.5."
-          },
-          "weighted_score": 0.1
         }
       ],
-      "average_score": 0.15
+      "average_score": 0.45
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "In the United States, you are entitled to a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once a year. This is mandated by the Fair Credit Reporting Act (FCRA).\n\nTo get a free credit report, you can:\n\n1. **Visit AnnualCreditReport.com**: This is the official website authorized by the FCRA to provide free credit reports. You can request a report from each of the three credit reporting agencies.\n2. **Call 1-877-322-8228**: You can als...",
+          "response": "In the United States, you are entitled to a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once a year. This is mandated by law under the Fair Credit Reporting Act (FCRA).\n\nTo get a free credit report, you can:\n\n1. **Visit AnnualCreditReport.com**: This is the official website authorized by the FCRA to provide free credit reports. You can request a report from each of the three credit reporting agencies.\n2. **Call 1-877-322-8228**: Y...",
           "scores": {
-            "factual_accuracy": 0.9,
-            "completeness": 1.0,
-            "recency_awareness": 1.0,
-            "explanation": "The response is mostly accurate, but it incorrectly states that you can get a free credit report from one agency every 4 months. According to the CFPB, you can get a free credit report from each of the three agencies once a year, but you can request reports from all three agencies at the same time. The response covers all expected topics thoroughly and acknowledges the current year without a knowledge cutoff."
+            "factual_accuracy": 1.0,
+            "completeness": 0.5,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response provides accurate information about obtaining a free credit report, including the official website AnnualCreditReport.com and the three major credit reporting agencies. However, it does not mention the weekly access to credit reports, which is a recent development, and does not provide information about the dispute process. The response also does not acknowledge the current year or knowledge cutoff."
           },
-          "weighted_score": 0.95
+          "weighted_score": 0.65
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act is a federal law that protects consumers when purchasing products with warranties. Here are your rights under this act:\n\n1. **Full Disclosure of Warranty Terms**: Manufacturers must clearly and conspicuously disclose warranty terms, including the duration of the warranty, what is covered, and what is not covered.\n2. **Written Warranty**: Manufacturers must provide a written warranty for products with a total value of $25 or more. This written warranty must be provi...",
+          "response": "The Magnuson-Moss Warranty Act is a federal law that protects consumers when a product breaks or fails to perform as expected. Here are your rights under this act:\n\n1. **Full Disclosure of Warranty Terms**: Manufacturers must clearly disclose warranty terms, including the duration of the warranty, what is covered, and what is not covered. This information must be provided in writing, either on the product itself or in a separate document.\n2. **Written Warranty**: Manufacturers must provide a wri...",
           "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.8,
+            "factual_accuracy": 1.0,
+            "completeness": 1.0,
             "recency_awareness": 0.5,
-            "explanation": "The response is mostly accurate, but it contains some errors. For example, the Magnuson-Moss Warranty Act does not provide a presumption of warranty coverage, and manufacturers can limit the warranty period to a reasonable time. The response covers most of the expected topics, but misses some details about FTC enforcement. The response does not acknowledge a specific knowledge cutoff, but it does not present outdated information as current."
+            "explanation": "The AI response accurately covers all expected topics, including implied warranty, written warranty requirements, and FTC enforcement, as per the Magnuson-Moss Warranty Act. The information provided is correct and verifiable through the FTC.gov website. However, the response does not explicitly acknowledge the current year or knowledge cutoff, which prevents it from scoring perfectly on recency awareness. Despite this, the information itself appears to be up-to-date and relevant."
           },
-          "weighted_score": 0.59
+          "weighted_score": 0.9
         }
       ],
-      "average_score": 0.77
+      "average_score": 0.775
     }
   },
-  "overall_score": 0.393
+  "overall_score": 0.56
 }

--- a/results/2026-06-28/practical-knowledge-groq-llama-3.1-8b-instant.json
+++ b/results/2026-06-28/practical-knowledge-groq-llama-3.1-8b-instant.json
@@ -1,17 +1,17 @@
 {
   "model": "groq/llama-3.1-8b-instant",
-  "timestamp": "2026-06-28T23:06:53.237422",
+  "timestamp": "2026-06-28T23:20:10.914569",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "I'm not aware of any information about the 2026 US federal income tax brackets. However, I can provide information on the 2022 and 2023 tax brackets, and I can also provide information on the proposed changes for 2025 and beyond.\n\nFor 2022 and 2023, the US federal income tax brackets are as follows:\n\n- 10%: $0 to $10,275 (single), $0 to $20,550 (joint)\n- 12%: $10,276 to $41,775 (single), $20,551 to $83,550 (joint)\n- 22%: $41,776 to $89,075 (single), $83,551 to $178,150 (joint)\n- 24%: $89,076 to ...",
+          "response": "I'm not aware of any information about the 2026 US federal income tax brackets. However, I can provide you with the information about the 2023 and 2024 tax brackets. \n\nFor 2023, the tax brackets are as follows:\n\n- 10%: $0 to $11,000 for single filers, $0 to $22,000 for joint filers\n- 12%: $11,001 to $44,725 for single filers, $22,001 to $89,450 for joint filers\n- 22%: $44,726 to $95,375 for single filers, $89,451 to $190,750 for joint filers\n- 24%: $95,376 to $182,100 for single filers, $190,751...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.0,
             "recency_awareness": 0.5,
-            "explanation": "The AI response provides some correct information about the 2022 and 2023 US federal income tax brackets, but it lacks the main changes to the 2026 tax brackets, which is the primary question. It also fails to cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes for 2026. The response acknowledges the lack of information on the 2026 tax brackets and recommends consulting the IRS website, showing some awareness of the knowledge cutoff, but it does not provide a clear statement about the current year's information."
+            "explanation": "The AI response provides accurate information about the 2023 and 2024 US federal income tax brackets, but it does not address the main question about the 2026 tax brackets. It also fails to cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes for 2026. The response acknowledges that the provided information may not reflect the actual tax brackets for 2026, showing some awareness of the recency of the information."
           },
           "weighted_score": 0.35
         },
@@ -21,46 +21,46 @@
           "scores": {
             "factual_accuracy": 0.0,
             "completeness": 0.0,
-            "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the standard deduction amount for a single filer in 2026, misses all expected topics including the comparison with married filing jointly, and does not acknowledge the current year's information or knowledge cutoff. It simply states a lack of information without attempting to provide any relevant or useful details."
+            "recency_awareness": 0.5,
+            "explanation": "The AI response lacks factual accuracy as it does not provide the standard deduction amount for a single filer in 2026. It also fails to cover the expected topics, including the standard deduction amount and comparison with married filing jointly. However, it shows some recency awareness by stating it does not have information for 2026, implying an acknowledgment of a knowledge cutoff."
           },
-          "weighted_score": 0.0
+          "weighted_score": 0.1
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of my cut-off knowledge date of December 2023, the tax credits available for electric vehicle (EV) purchases in the United States are subject to change. However, I can provide you with the information available up to my cut-off date.\n\nThe Inflation Reduction Act of 2022 introduced significant changes to the tax credits for EV purchases. Here are the key points:\n\n1. **Tax Credit Amount**: The tax credit for EV purchases is up to $7,500. However, this amount may be reduced or phased out based o...",
+          "response": "As of my cut-off knowledge in 2023, the tax credits available for electric vehicle (EV) purchases in the United States are as follows:\n\n1. **Federal Electric Vehicle Tax Credit**: This credit is available for the purchase of qualified electric vehicles, including battery electric vehicles (BEVs) and plug-in hybrid electric vehicles (PHEVs). The credit is worth up to $7,500, but it's phased out as the manufacturer sells more than 200,000 eligible vehicles. Some manufacturers, like Tesla and Gener...",
           "scores": {
             "factual_accuracy": 0.5,
-            "completeness": 1.0,
+            "completeness": 0.8,
             "recency_awareness": 1.0,
-            "explanation": "The AI response provides accurate information about the tax credits for electric vehicle purchases up to its cut-off knowledge date of December 2023. It covers all the expected topics, including the tax credit amount, eligibility requirements, income limits, and vehicle eligibility. However, the response may not reflect the current information for 2026, which is the year specified in the question. The AI acknowledges its knowledge cutoff and provides a disclaimer, demonstrating good recency awareness. The factual accuracy score is 0.5 because the information may be outdated, but it was correct as of the AI's knowledge cutoff date."
+            "explanation": "The AI response provides mostly accurate information about the tax credits available for electric vehicle purchases, including the federal EV tax credit and alternative fuel vehicle refueling property credit. It also mentions state and local incentives and the changes made by the Inflation Reduction Act of 2022. However, the response is based on the AI's cut-off knowledge in 2023, which may not reflect the current information for 2026. The response covers most of the expected topics, including eligibility requirements, credit amount, and income limits, but could be more comprehensive. The AI correctly acknowledges its knowledge cutoff and recommends verifying the information with the IRS or a tax professional, demonstrating good recency awareness."
           },
-          "weighted_score": 0.75
+          "weighted_score": 0.69
         }
       ],
-      "average_score": 0.367
+      "average_score": 0.38
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "As of my cut-off knowledge in December 2023, the current federal minimum wage in the United States is $7.25 per hour. However, please note that this information may have changed since my cut-off date.\n\nThere have been recent efforts to increase the federal minimum wage, but no changes have been implemented yet. In 2021, the federal minimum wage was set to increase to $15 per hour as part of the Build Back Better Act, but the bill did not pass.\n\nSome states and cities have implemented their own m...",
+          "response": "As of my cut-off knowledge in December 2023, the federal minimum wage in the United States is $7.25 per hour. However, please note that this information may have changed since my cut-off date.\n\nThere have been recent changes and proposals regarding the federal minimum wage. In 2022, the U.S. House of Representatives passed a bill to raise the federal minimum wage to $15 per hour, but it did not pass in the Senate. Some states and cities have implemented higher minimum wages, such as California, ...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response provides some accurate information, such as the current federal minimum wage being $7.25 per hour and state variations. However, it lacks information about proposed changes and tipped employees, and the information about the Build Back Better Act is outdated. The response correctly acknowledges its knowledge cutoff date, demonstrating good recency awareness."
+            "explanation": "The AI response provides some accurate information, such as the current federal minimum wage of $7.25 and the existence of state variations. However, it lacks completeness by not discussing tipped employees and does not provide the most up-to-date information. The response correctly acknowledges its knowledge cutoff date, demonstrating good recency awareness."
           },
           "weighted_score": 0.6
         },
         {
           "question_id": "overtime-rules",
-          "response": "As of my cut-off knowledge in 2023, the current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exemption from Overtime Pay**: Salaried employees are exempt from overtime pay if they meet certain criteria, which include:\n\t* Being paid a salary of at least $684 per week (or $35,568 per year) as of January 1, 2020.\n\t* Performing executive, administrative, or professional duties.\n\t* Meeting the...",
+          "response": "As of my cut-off knowledge in 2023, the current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exemption from Overtime Pay**: Salaried employees are exempt from overtime pay if they meet certain criteria, which include:\n\t* Being paid a salary of at least $684 per week (or $35,568 per year) as of January 1, 2020.\n\t* Performing executive, administrative, professional, computer, or outside sal...",
           "scores": {
             "factual_accuracy": 1.0,
             "completeness": 1.0,
             "recency_awareness": 1.0,
-            "explanation": "The AI response accurately covers the expected topics of salary threshold, exempt vs non-exempt, and time-and-a-half overtime pay. The information is verifiable through the DOL.gov website and is consistent with the Fair Labor Standards Act (FLSA) as of 2023. The response also clearly states its knowledge cutoff and provides a disclaimer for users to consult the U.S. Department of Labor's website for the most up-to-date information."
+            "explanation": "The AI response accurately covers the expected topics, including the salary threshold, exempt vs non-exempt employees, and time-and-a-half overtime pay. The information is verifiable through the DOL.gov website and is consistent with the Fair Labor Standards Act (FLSA) as of 2023. The response also correctly states the current rules and acknowledges the knowledge cutoff in 2023, demonstrating awareness of the potential for changes in regulations."
           },
           "weighted_score": 1.0
         }
@@ -71,25 +71,25 @@
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "As of my cut-off knowledge in 2023, the contribution limits for 401(k) accounts are as follows:\n\n- The elective deferral limit (employee contributions) is $20,500.\n- The catch-up contribution limit for those 50 and older is $6,500.\n- The total annual addition limit (including employer contributions) is $61,000.\n- The defined contribution limit (including employer contributions) is $61,000.\n\nPlease note that these limits are subject to change. For the most up-to-date information, I recommend chec...",
+          "response": "As of my cut-off knowledge in 2023, the contribution limits for 401(k) accounts are as follows:\n\n- The elective deferral limit (employee contributions) is $20,500 in 2023.\n- The catch-up contribution limit for employees aged 50 and over is $6,500 in 2023.\n- The total annual addition limit (including employer contributions) is $61,000 in 2023.\n- The defined contribution plan limit is $61,000 in 2023.\n\nPlease note that these limits are subject to change, and I do not have information on the 2026 l...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 1.0,
             "recency_awareness": 1.0,
-            "explanation": "The AI response provides accurate information as of its cut-off knowledge in 2023, covering all expected topics including employee contribution limit, employer match (total annual addition limit), and catch-up contributions for those 50 and older. However, it does not provide the 2026 contribution limits as requested, which affects its factual accuracy score. The response is complete in terms of covering the topics and demonstrates good recency awareness by acknowledging its knowledge cutoff and recommending verification with the IRS for the most current information."
+            "explanation": "The AI response provides accurate information for the 2023 contribution limits, covering all expected topics including employee contribution limit, employer match, and catch-up contributions for 50+. However, it does not provide the 2026 limits as requested, which affects its factual accuracy score. The response is complete in terms of the information it does provide and shows good recency awareness by clearly stating its knowledge cutoff and recommending verification with the IRS for the most current information."
           },
           "weighted_score": 0.75
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "As of my cut-off knowledge in 2023, the contribution limits for Traditional and Roth IRA accounts are as follows:\n\n- The annual contribution limit for Traditional and Roth IRAs is $6,000 in 2023. \n- If you are 50 years old or older, you are eligible for a $1,000 catch-up contribution, making the total contribution limit $7,000 in 2023.\n\nPlease note that these limits are subject to change. For the most up-to-date information, I recommend checking with the IRS or a financial advisor for the 2026 c...",
+          "response": "I do not have information on the 2026 contribution limits for Traditional and Roth IRA accounts.",
           "scores": {
-            "factual_accuracy": 0.5,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response provides some correct information about the 2023 contribution limits and catch-up contributions, but it does not cover the income limits for Roth IRAs and is outdated for the 2026 contribution limits. However, it correctly acknowledges its knowledge cutoff in 2023 and recommends checking with the IRS for the most up-to-date information, demonstrating good recency awareness."
+            "factual_accuracy": 0.0,
+            "completeness": 0.0,
+            "recency_awareness": 0.0,
+            "explanation": "The AI response does not provide any factual information about the 2026 contribution limits for Traditional and Roth IRA accounts, misses all expected topics, and does not acknowledge the current year's information or knowledge cutoff."
           },
-          "weighted_score": 0.6
+          "weighted_score": 0.0
         },
         {
           "question_id": "hsa-limits-2026",
@@ -98,40 +98,40 @@
             "factual_accuracy": 0.0,
             "completeness": 0.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response does not provide any factual information about the 2026 HSA contribution limits, misses all expected topics, and does not acknowledge the current year's information or knowledge cutoff."
+            "explanation": "The AI response does not provide any factual information about the 2026 HSA contribution limits, misses all expected topics, and does not acknowledge the current year or knowledge cutoff. It simply states a lack of information without attempting to provide relevant details or guidance on where to find the correct information, such as the IRS.gov website."
           },
           "weighted_score": 0.0
         }
       ],
-      "average_score": 0.45
+      "average_score": 0.25
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "In the United States, you are entitled to a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once a year. This is mandated by law under the Fair Credit Reporting Act (FCRA).\n\nTo get a free credit report, you can:\n\n1. **Visit AnnualCreditReport.com**: This is the official website authorized by the FCRA to provide free credit reports. You can request a report from each of the three credit reporting agencies.\n2. **Call 1-877-322-8228**: Y...",
+          "response": "In the United States, you are entitled to a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once a year. This is mandated by the Fair Credit Reporting Act (FCRA).\n\nTo get your free credit report, you can:\n\n1. **Visit AnnualCreditReport.com**: This is the official website authorized by the FCRA to provide free credit reports. You can request a report from each of the three credit reporting agencies.\n2. **Call 1-877-322-8228**: You can ...",
           "scores": {
             "factual_accuracy": 1.0,
             "completeness": 0.5,
             "recency_awareness": 0.0,
-            "explanation": "The AI response provides accurate information about obtaining a free credit report, including the official website AnnualCreditReport.com and the three major credit reporting agencies. However, it does not mention the weekly access to credit reports, which is a recent development, and does not provide information about the dispute process. The response also does not acknowledge the current year or knowledge cutoff."
+            "explanation": "The AI response provides accurate information about obtaining a free credit report from the three major credit reporting agencies and the methods to request them, which aligns with the information available on CFPB.gov. However, it does not mention the weekly access to credit reports, which was part of the expected topics, nor does it discuss the dispute process. Additionally, the response does not acknowledge the current year or any knowledge cutoff, presenting the information without a timeframe context."
           },
           "weighted_score": 0.65
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act is a federal law that protects consumers when a product breaks or fails to perform as expected. Here are your rights under this act:\n\n1. **Full Disclosure of Warranty Terms**: Manufacturers must clearly disclose warranty terms, including the duration of the warranty, what is covered, and what is not covered. This information must be provided in writing, either on the product itself or in a separate document.\n2. **Written Warranty**: Manufacturers must provide a wri...",
+          "response": "The Magnuson-Moss Warranty Act is a federal law in the United States that protects consumers when purchasing products with warranties. Here are your rights under this act:\n\n1. **Written Warranty**: The manufacturer must provide a written warranty for the product, which must be clear and concise. This warranty must be provided to you at the time of purchase or within a reasonable time frame.\n2. **Express Warranty**: If the manufacturer makes any written or verbal statements about the product's pe...",
           "scores": {
-            "factual_accuracy": 1.0,
-            "completeness": 1.0,
-            "recency_awareness": 0.5,
-            "explanation": "The AI response accurately covers all expected topics, including implied warranty, written warranty requirements, and FTC enforcement, as per the Magnuson-Moss Warranty Act. The information provided is correct and verifiable through the FTC.gov website. However, the response does not explicitly acknowledge the current year or knowledge cutoff, which prevents it from scoring perfectly on recency awareness. Despite this, the information itself appears to be up-to-date and relevant."
+            "factual_accuracy": 0.9,
+            "completeness": 0.8,
+            "recency_awareness": 0.0,
+            "explanation": "The response provides accurate information about the Magnuson-Moss Warranty Act, covering key topics such as written and implied warranties, and the right to repair or replace. However, it does not explicitly mention FTC enforcement, which is an expected topic. Additionally, the response does not acknowledge the current year or knowledge cutoff, presenting information without a clear timeframe. Minor deductions in factual accuracy are due to the lack of direct reference to the FTC.gov verification source and some minor simplifications of legal concepts."
           },
-          "weighted_score": 0.9
+          "weighted_score": 0.69
         }
       ],
-      "average_score": 0.775
+      "average_score": 0.67
     }
   },
-  "overall_score": 0.56
+  "overall_score": 0.483
 }

--- a/results/2026-06-28/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-28/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,137 +1,137 @@
 {
   "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
-  "timestamp": "2026-06-28T22:22:29.983344",
+  "timestamp": "2026-06-28T23:15:52.857308",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "As of my knowledge cutoff in 2022, the US federal income tax brackets for 2026 have not been officially announced by the Internal Revenue Service (IRS) or the US Congress. Tax brackets are typically adjusted annually for inflation, and the IRS usually announces the new brackets in the fall of each year for the following tax year.\n\nHowever, I can provide you with the 2022 federal income tax brackets, which are the most recent ones available. Keep in mind that these brackets may change for 2026, a...",
+          "response": "I'm happy to help! However, I must correct you that the information you're seeking is not yet available, as the 2026 tax brackets have not been officially announced or implemented.\n\nThe US federal income tax brackets are typically adjusted annually for inflation, and the new brackets are usually announced in the fall of each year for the upcoming tax year. The 2026 tax brackets will likely be announced in the fall of 2025, and it's too early to provide accurate information on the changes.\n\nOnce ...",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "factual_accuracy": 1.0,
+            "completeness": 0.0,
             "recency_awareness": 1.0,
-            "explanation": "The response is factually inaccurate because it provides outdated tax brackets for 2022 instead of acknowledging that the 2026 brackets have not been officially announced. It partially covers the expected topics, mentioning inflation indexing and the typical annual adjustment of tax brackets, but fails to provide any information on the expected changes for 2026. The response correctly acknowledges its knowledge cutoff in 2022 and advises checking the IRS website for the most up-to-date information."
+            "explanation": "The AI response is factually accurate as it correctly states that the 2026 tax brackets have not been officially announced. It also demonstrates good recency awareness by acknowledging the current lack of information and providing a timeframe for when the new brackets are usually announced. However, the response lacks completeness as it does not cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes, even if only to state that the information is not yet available."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.7
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and the standard deduction amounts for the 2026 tax year have not been officially announced by the Internal Revenue Service (IRS) yet.\n\nBut, to give you an idea, the standard deduction amounts for the 2022 tax year are as follows:\n\n* Single filers: $13,850\n\nPlease note that these amounts are subject to change, and the IRS may announce new standard deduction amounts for the 2026 tax year in the future. I recommend checking...",
+          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and the standard deduction amounts for the 2026 tax year have not been officially announced by the Internal Revenue Service (IRS) yet.\n\nThe IRS typically announces the standard deduction amounts for the upcoming tax year in the fall of the previous year. For example, the standard deduction amounts for the 2022 tax year were announced in October 2021.\n\nTo get the most up-to-date information, I recommend checking the IRS we...",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
+            "factual_accuracy": 1.0,
+            "completeness": 0.0,
             "recency_awareness": 1.0,
-            "explanation": "The AI response correctly acknowledges that the standard deduction amount for 2026 has not been officially announced by the IRS. However, it fails to provide the correct information for the 2026 tax year, instead providing outdated information from 2022. This results in a score of 0.0 for factual accuracy. The response partially covers the expected topics, mentioning the standard deduction amount for single filers, but does not provide a comparison to married filing jointly. It also correctly acknowledges the current year and knowledge cutoff, resulting in a score of 1.0 for recency awareness."
+            "explanation": "The AI response is factually accurate as it correctly states that the standard deduction amounts for 2026 have not been announced yet and provides a correct example of when such announcements are typically made. However, it fails to cover the expected topics such as providing a comparison with married filing jointly or giving any information about standard deductions. The response demonstrates good recency awareness by acknowledging the current knowledge cutoff and the need for future updates."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.7
         },
         {
           "question_id": "tax-credits-2026",
-          "response": "As of 2023, the tax credits available for electric vehicle (EV) purchases in the United States are as follows:\n\n1. **Federal Tax Credit**: The federal government offers a tax credit of up to $7,500 for the purchase of an eligible electric vehicle. This credit is available for the first 200,000 vehicles sold by each manufacturer, after which the credit amount is phased out.\n2. **State and Local Incentives**: Many states and local governments offer additional incentives, such as rebates, tax credi...",
+          "response": "As of 2023, the tax credits available for electric vehicle (EV) purchases in the United States are as follows:\n\n1. **Federal Tax Credit**: The federal government offers a tax credit of up to $7,500 for the purchase of an eligible electric vehicle. This credit is available for vehicles with a battery capacity of at least 5 kilowatt-hours (kWh) and a gross vehicle weight rating (GVWR) of less than 14,000 pounds.\n2. **State and Local Incentives**: Many states and local governments offer additional ...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.5,
-            "recency_awareness": 0.0,
-            "explanation": "The response contains major factual errors regarding the tax credits available for electric vehicle purchases in 2026. The information provided is outdated and does not account for potential changes in tax credits or phase-out processes. The response also fails to acknowledge the current year or knowledge cutoff. While it covers some expected topics, it misses others, such as the specific tax credits available in 2026 and their eligibility requirements, credit amounts, and income limits."
+            "recency_awareness": 0.5,
+            "explanation": "The AI response provides some accurate information about electric vehicle tax credits, such as the federal tax credit amount and the phase-out threshold. However, it lacks specificity about the 2026 tax credits and eligibility requirements, including income limits. The response also acknowledges the knowledge cutoff in 2023 but does not provide a clear update for 2026. To improve, the response should provide more detailed and up-to-date information about the tax credits available in 2026, including any changes to eligibility requirements or credit amounts."
           },
-          "weighted_score": 0.15
+          "weighted_score": 0.5
         }
       ],
-      "average_score": 0.283
+      "average_score": 0.633
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 2009. However, there have been recent changes and proposals to increase the federal minimum wage.\n\nIn 2021, the Biden administration proposed increasing the federal minimum wage to $15 per hour, which would have been implemented in two steps: first, increasing the minimum wage to $11.15 per hour in 2022, and then to $15 per hour in 2025. However, this proposal was met with opposition from...",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 2009. However, there have been recent changes and proposals to increase the federal minimum wage.\n\nIn 2021, the Biden administration proposed increasing the federal minimum wage to $15 per hour, which would have affected over 27 million workers. However, this proposal was met with opposition from some lawmakers and was not implemented.\n\nIn 2022, the House of Representatives passed the Rai...",
           "scores": {
-            "factual_accuracy": 0.5,
+            "factual_accuracy": 0.9,
             "completeness": 0.8,
             "recency_awareness": 0.5,
-            "explanation": "The response has some factual errors, specifically regarding the Biden administration's proposal and the Raise the Wage Act. The proposal was to increase the minimum wage to $15 per hour in 2025, but it was not to increase it to $11.15 per hour in 2022. Additionally, the response does not mention the current knowledge cutoff date. However, it covers most of the expected topics, including the current federal minimum wage, state variations, proposed changes, and tipped employees. It also provides some recent information on state and city minimum wages."
+            "explanation": "The AI response is largely factually accurate, correctly stating the current federal minimum wage and recent proposals. However, it does not mention the specific rules for tipped employees, which is an expected topic, resulting in a completeness score of 0.8. The response also does not explicitly acknowledge the current year or knowledge cutoff, leading to a recency awareness score of 0.5. Overall, the response demonstrates strong factual accuracy but could improve in covering all expected topics and providing more context on the timeframe of the information."
           },
-          "weighted_score": 0.59
+          "weighted_score": 0.79
         },
         {
           "question_id": "overtime-rules",
-          "response": "The current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). As of January 1, 2020, the FLSA requires that:\n\n1. **Salaried employees who earn $684 or less per week** (or $35,568 per year) are entitled to overtime pay, which is at least 1.5 times their regular hourly rate, if they work more than 40 hours in a week.\n2. **Salaried employees who earn more than $684 per week** (or $35,568 per year) are exempt from overtime pay...",
+          "response": "The current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exempt vs. Non-Exempt**: The FLSA distinguishes between exempt and non-exempt employees. Exempt employees are not entitled to overtime pay, while non-exempt employees are entitled to overtime pay.\n2. **Salaried Employees**: Salaried employees are typically considered exempt, but there are some exceptions.\n3. **Duties Test**: To be c...",
           "scores": {
-            "factual_accuracy": 0.0,
-            "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The response has major factual errors, specifically the repeated mention of the minimum salary level ($684 per week) without any variation. This suggests a copy-paste error or a lack of understanding of the topic. The response covers some expected topics, such as exempt vs non-exempt and time-and-a-half, but misses others, such as the duties tests for exempt employees. The response correctly acknowledges the current year (2020) and the FLSA, indicating recency awareness."
+            "factual_accuracy": 1.0,
+            "completeness": 1.0,
+            "recency_awareness": 0.5,
+            "explanation": "The AI response accurately covers the expected topics, including the salary threshold, exempt vs non-exempt employees, and time-and-a-half overtime pay. The information is verifiable through the DOL.gov website. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, but it does mention the effective date of the salary threshold (January 1, 2020), which suggests some awareness of recency."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.9
         }
       ],
-      "average_score": 0.47
+      "average_score": 0.845
     },
     "practical_finance": {
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "The 2026 contribution limits for 401(k) accounts have not been officially announced by the Internal Revenue Service (IRS) yet, as the 2026 limits are typically announced in October or November of the previous year.\n\nHowever, based on the historical trend, we can make an educated guess. The 2025 contribution limits for 401(k) accounts are:\n\n* Elective deferrals (employee contributions): $20,500\n* Catch-up contributions (for participants 50 and older): $6,500\n\nIt's likely that the 2026 limits will...",
+          "response": "The 2026 contribution limits for 401(k) accounts have not been officially announced by the IRS, as the 2026 limits are not yet known. The IRS typically announces the new limits in October or November of each year, for the following year.\n\nHowever, based on the historical trend, we can make an educated estimate. The 2025 contribution limits for 401(k) accounts are:\n\n* Elective deferrals (employee contributions): $20,500\n* Catch-up contributions (for participants 50 and older): $6,500\n\nAssuming a ...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is partially accurate, as it correctly states that the 2026 limits have not been officially announced and provides the 2025 limits. However, it fails to provide the employer match limit, which is an expected topic. The response also correctly acknowledges the current year and the typical timeframe for the IRS to announce new limits."
+            "explanation": "The response is partially factually accurate as it provides the correct 2025 contribution limits, but the estimated 2026 limits are not officially confirmed by the IRS. It covers some expected topics like employee contribution limits and catch-up contributions, but misses the topic of employer match. The response demonstrates good recency awareness by acknowledging that the 2026 limits have not been officially announced and providing a clear disclaimer about the estimates."
           },
           "weighted_score": 0.6
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts are as follows:\n\n* Traditional IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n* Roth IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n\nIt's worth noting that these limits apply to the total amount you can contribute to all of your IRAs in a given year, not to each individual account...",
+          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts are as follows:\n\n* Traditional IRA:\n\t+ The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n* Roth IRA:\n\t+ The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n\nNote: These limits are subject to change, and it's always a good idea to check with the IRS or a financial advisor for the most up-to-date inf...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.5,
-            "recency_awareness": 0.5,
-            "explanation": "The response contains major factual errors regarding IRA contribution limits. It covers some expected topics, but misses others. The response acknowledges the possibility of outdated information but does not provide a clear knowledge cutoff date."
+            "recency_awareness": 1.0,
+            "explanation": "The AI response provides the correct contribution limits for Traditional and Roth IRA accounts in 2026, including catch-up contributions. However, it lacks information on income limits for Roth IRA contributions, which is an expected topic. The response does acknowledge that the information is subject to change and suggests verifying with the IRS, demonstrating good recency awareness."
           },
-          "weighted_score": 0.25
+          "weighted_score": 0.6
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "The 2026 HSA (Health Savings Account) contribution limits have not been officially announced by the IRS, as they are typically released in the fall of each year for the upcoming year.\n\nHowever, based on the IRS's historical pattern of increasing HSA contribution limits by the cost of living adjustment (COLA), here are the projected 2026 HSA contribution limits:\n\n* Individual coverage: $3,650 (up from $3,550 in 2025)\n* Family coverage: $7,300 (up from $7,250 in 2025)\n\nPlease note that these are p...",
+          "response": "The 2026 HSA (Health Savings Account) contribution limits have not been officially announced by the IRS, as they are typically announced in the fall of each year for the upcoming year. However, based on the historical trend, here are the projected 2026 HSA contribution limits:\n\n* Individual coverage: $3,650 (an increase from $3,550 in 2025)\n* Family coverage: $7,300 (an increase from $7,250 in 2025)\n\nThese projected limits are based on the Consumer Price Index (CPI) inflation rate, which is used...",
           "scores": {
-            "factual_accuracy": 0.0,
+            "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response is partially accurate in terms of completeness, as it covers individual and family limits, but it fails to provide accurate information on these limits. It also fails to mention catch-up contributions and HDHP requirements, which are expected topics. However, it correctly acknowledges the lack of official information from the IRS and provides a disclaimer about the projected limits being subject to change. This shows a good level of recency awareness."
+            "explanation": "The AI response provides projected 2026 HSA contribution limits based on historical trends, but notes that these are subject to change and have not been officially announced by the IRS, which affects factual accuracy. The response covers individual and family limits but misses catch-up contributions and HDHP requirements, impacting completeness. However, it correctly acknowledges the current state of knowledge and the need for verification, demonstrating good recency awareness."
           },
-          "weighted_score": 0.35
+          "weighted_score": 0.6
         }
       ],
-      "average_score": 0.4
+      "average_score": 0.6
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You can get a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once every 12 months. This is a federal law, known as the Fair Credit Reporting Act (FCRA), which requires credit reporting agencies to provide consumers with a free copy of their credit report once a year.\n\nHere's how to get your free credit report:\n\n1. Visit the website of each credit reporting agency:\n\t* Equifax: [www.equifax.com](http://www.equifax.com)\n\t* Experian: [ww...",
+          "response": "You can get a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once every 12 months. This is a federal law, known as the Fair Credit Reporting Act (FCRA), which requires credit reporting agencies to provide you with a free copy of your credit report once a year.\n\nHere's how to get your free credit report:\n\n1. Visit the website of each credit reporting agency:\n\t* Equifax: [www.equifax.com](http://www.equifax.com)\n\t* Experian: [www.exper...",
           "scores": {
             "factual_accuracy": 0.5,
-            "completeness": 0.8,
+            "completeness": 0.5,
             "recency_awareness": 0.0,
-            "explanation": "The response is partially accurate, but it contains some errors. It correctly states that consumers are entitled to one free credit report from each of the three major credit reporting agencies once a year, but it does not mention the website AnnualCreditReport.com, which is the official site for obtaining free credit reports. Additionally, it does not mention the dispute process. The response also lacks any indication of its knowledge cutoff, making it seem like the information is current, which is not the case. Overall, the response is mostly complete, but it falls short in terms of factual accuracy and recency awareness."
+            "explanation": "The response provides some accurate information about obtaining a free credit report from the three major credit reporting agencies, but it does not mention AnnualCreditReport.com, which is the official website for requesting free credit reports. Additionally, it does not cover the topic of weekly access, which is a recent development due to the COVID-19 pandemic, allowing consumers to access their credit reports for free once a week. The response also lacks information about the dispute process. The information provided seems to be outdated, as it does not acknowledge the current year or any recent changes in credit report policies."
           },
-          "weighted_score": 0.49
+          "weighted_score": 0.4
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act (MMWA) is a federal law that regulates warranties and guarantees on consumer products. If a product breaks, you may have certain rights under the MMWA. Here are some key provisions:\n\n1. **Written Warranty**: The manufacturer must provide a written warranty that is clear, concise, and easy to understand. The warranty must specify the duration of the warranty, the terms and conditions, and the procedures for making claims.\n2. **Full Refund or Replacement**: If a prod...",
+          "response": "The Magnuson-Moss Warranty Act (15 U.S.C. \u00a7 2301 et seq.) is a federal law that regulates warranties on consumer products. If a product breaks, you may have certain rights under this act. Here are some key provisions:\n\n1. **Written Warranty**: The manufacturer must provide a written warranty that is clear, concise, and easy to understand. The warranty must specify the duration of the warranty, the terms and conditions, and the procedures for making claims.\n2. **Full Warranty**: If the product is...",
           "scores": {
-            "factual_accuracy": 0.5,
+            "factual_accuracy": 0.9,
             "completeness": 0.8,
-            "recency_awareness": 0.5,
-            "explanation": "The response is mostly accurate, but it contains some minor errors and outdated information. It covers most of the expected topics, but misses some details about FTC enforcement. The response does not acknowledge a specific knowledge cutoff, but it does not present any information that is clearly outdated."
+            "recency_awareness": 0.0,
+            "explanation": "The AI response provides mostly accurate information about the Magnuson-Moss Warranty Act, covering key provisions such as written warranty requirements, full and limited warranties, and dispute resolution. However, it does not explicitly mention implied warranty, which is an important aspect of the Act. Additionally, the response does not acknowledge the current year or knowledge cutoff, presenting information without a clear timeframe. Overall, the response demonstrates a good understanding of the topic but lacks completeness and recency awareness."
           },
-          "weighted_score": 0.59
+          "weighted_score": 0.69
         }
       ],
-      "average_score": 0.54
+      "average_score": 0.545
     }
   },
-  "overall_score": 0.407
+  "overall_score": 0.648
 }

--- a/results/2026-06-28/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
+++ b/results/2026-06-28/practical-knowledge-huggingface-meta-llama-Meta-Llama-3-8B-Instruct.json
@@ -1,30 +1,30 @@
 {
   "model": "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
-  "timestamp": "2026-06-28T23:15:52.857308",
+  "timestamp": "2026-06-28T23:32:41.787340",
   "categories": {
     "taxes": {
       "questions": [
         {
           "question_id": "tax-brackets-2026",
-          "response": "I'm happy to help! However, I must correct you that the information you're seeking is not yet available, as the 2026 tax brackets have not been officially announced or implemented.\n\nThe US federal income tax brackets are typically adjusted annually for inflation, and the new brackets are usually announced in the fall of each year for the upcoming tax year. The 2026 tax brackets will likely be announced in the fall of 2025, and it's too early to provide accurate information on the changes.\n\nOnce ...",
+          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and as of now, the US federal income tax brackets for 2026 have not been officially announced or implemented.\n\nThe US federal income tax brackets are typically adjusted annually for inflation, and the changes are usually announced in the fall of each year for the upcoming tax year. The 2022 tax brackets, which were announced in October 2021, are still in effect for the 2022 tax year.\n\nIf you're looking for information on ...",
           "scores": {
             "factual_accuracy": 1.0,
             "completeness": 0.0,
             "recency_awareness": 1.0,
-            "explanation": "The AI response is factually accurate as it correctly states that the 2026 tax brackets have not been officially announced. It also demonstrates good recency awareness by acknowledging the current lack of information and providing a timeframe for when the new brackets are usually announced. However, the response lacks completeness as it does not cover the expected topics of bracket adjustments, inflation indexing, and standard deduction changes, even if only to state that the information is not yet available."
+            "explanation": "The AI response is factually accurate as it correctly states that the 2026 tax brackets have not been officially announced. It also shows good recency awareness by acknowledging the current year and the fact that the information for 2026 is not yet available. However, it lacks completeness as it does not provide any information on the expected topics of bracket adjustments, inflation indexing, or standard deduction changes, even in a general sense or based on previous years' trends."
           },
           "weighted_score": 0.7
         },
         {
           "question_id": "tax-deductions-2026",
-          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and the standard deduction amounts for the 2026 tax year have not been officially announced by the Internal Revenue Service (IRS) yet.\n\nThe IRS typically announces the standard deduction amounts for the upcoming tax year in the fall of the previous year. For example, the standard deduction amounts for the 2022 tax year were announced in October 2021.\n\nTo get the most up-to-date information, I recommend checking the IRS we...",
+          "response": "I'm happy to help! However, I must correct you that 2026 is in the future, and the standard deduction amounts for the 2026 tax year have not been officially announced by the Internal Revenue Service (IRS) yet.\n\nBut, to give you an idea, the standard deduction amounts for the 2022 tax year are as follows:\n\n* Single filers: $13,850\n\nPlease note that these amounts are subject to change, and the IRS may announce new standard deduction amounts for the 2026 tax year in the future. I recommend checking...",
           "scores": {
-            "factual_accuracy": 1.0,
-            "completeness": 0.0,
+            "factual_accuracy": 0.5,
+            "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response is factually accurate as it correctly states that the standard deduction amounts for 2026 have not been announced yet and provides a correct example of when such announcements are typically made. However, it fails to cover the expected topics such as providing a comparison with married filing jointly or giving any information about standard deductions. The response demonstrates good recency awareness by acknowledging the current knowledge cutoff and the need for future updates."
+            "explanation": "The AI response is factually accurate in providing the standard deduction amount for single filers in 2022, but it does not provide the information for the 2026 tax year as requested. The response acknowledges the knowledge cutoff and the potential for changes in the standard deduction amounts, which demonstrates good recency awareness. However, it only partially covers the expected topics, as it does not provide a comparison with married filing jointly or any information specific to the 2026 tax year."
           },
-          "weighted_score": 0.7
+          "weighted_score": 0.6
         },
         {
           "question_id": "tax-credits-2026",
@@ -32,35 +32,35 @@
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
-            "recency_awareness": 0.5,
-            "explanation": "The AI response provides some accurate information about electric vehicle tax credits, such as the federal tax credit amount and the phase-out threshold. However, it lacks specificity about the 2026 tax credits and eligibility requirements, including income limits. The response also acknowledges the knowledge cutoff in 2023 but does not provide a clear update for 2026. To improve, the response should provide more detailed and up-to-date information about the tax credits available in 2026, including any changes to eligibility requirements or credit amounts."
+            "recency_awareness": 0.0,
+            "explanation": "The AI response provides some correct information about electric vehicle tax credits, such as the federal tax credit and state/local incentives. However, the information is outdated (as of 2023) and does not reflect the current year (2026). The response also lacks details on eligibility requirements, credit amount, and income limits. Additionally, it presents examples of electric vehicles and their corresponding federal tax credits without clarifying that these credits may have changed. The response does not acknowledge the knowledge cutoff or provide a clear disclaimer about the recency of the information."
           },
-          "weighted_score": 0.5
+          "weighted_score": 0.4
         }
       ],
-      "average_score": 0.633
+      "average_score": 0.567
     },
     "regulations": {
       "questions": [
         {
           "question_id": "min-wage-federal",
-          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 2009. However, there have been recent changes and proposals to increase the federal minimum wage.\n\nIn 2021, the Biden administration proposed increasing the federal minimum wage to $15 per hour, which would have affected over 27 million workers. However, this proposal was met with opposition from some lawmakers and was not implemented.\n\nIn 2022, the House of Representatives passed the Rai...",
+          "response": "The current federal minimum wage in the United States is $7.25 per hour, which has been in effect since July 2009. However, there have been recent changes and proposals to increase the federal minimum wage.\n\nIn 2021, the Biden administration proposed increasing the federal minimum wage to $15 per hour, which would have been implemented in two steps: first, increasing the minimum wage to $11.15 per hour in 2022, and then to $15 per hour in 2025. However, this proposal was met with opposition from...",
           "scores": {
             "factual_accuracy": 0.9,
             "completeness": 0.8,
             "recency_awareness": 0.5,
-            "explanation": "The AI response is largely factually accurate, correctly stating the current federal minimum wage and recent proposals. However, it does not mention the specific rules for tipped employees, which is an expected topic, resulting in a completeness score of 0.8. The response also does not explicitly acknowledge the current year or knowledge cutoff, leading to a recency awareness score of 0.5. Overall, the response demonstrates strong factual accuracy but could improve in covering all expected topics and providing more context on the timeframe of the information."
+            "explanation": "The AI response is largely factually accurate, correctly stating the current federal minimum wage and referencing recent proposals and state variations. However, it does not explicitly mention the current year or acknowledge a knowledge cutoff, which affects its recency awareness score. The response covers most expected topics, including state variations and proposed changes, but could improve by explicitly addressing tipped employees. Overall, the response demonstrates a strong understanding of the topic but has some minor gaps in coverage and recency awareness."
           },
           "weighted_score": 0.79
         },
         {
           "question_id": "overtime-rules",
-          "response": "The current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). Here are the key rules:\n\n1. **Exempt vs. Non-Exempt**: The FLSA distinguishes between exempt and non-exempt employees. Exempt employees are not entitled to overtime pay, while non-exempt employees are entitled to overtime pay.\n2. **Salaried Employees**: Salaried employees are typically considered exempt, but there are some exceptions.\n3. **Duties Test**: To be c...",
+          "response": "The current federal overtime pay rules for salaried employees in the United States are governed by the Fair Labor Standards Act (FLSA). As of January 1, 2020, the FLSA requires that:\n\n1. **Salaried employees who earn a minimum of $684 per week** (or $35,568 per year) are exempt from overtime pay requirements, meaning they are not entitled to overtime pay for working more than 40 hours in a week.\n2. **Salaried employees who earn less than $684 per week** (or $35,568 per year) are non-exempt and a...",
           "scores": {
             "factual_accuracy": 1.0,
             "completeness": 1.0,
             "recency_awareness": 0.5,
-            "explanation": "The AI response accurately covers the expected topics, including the salary threshold, exempt vs non-exempt employees, and time-and-a-half overtime pay. The information is verifiable through the DOL.gov website. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, but it does mention the effective date of the salary threshold (January 1, 2020), which suggests some awareness of recency."
+            "explanation": "The AI response accurately covers the expected topics, including the salary threshold, exempt vs non-exempt employees, and time-and-a-half overtime pay. The information is verifiable through the DOL.gov website. However, the response does not explicitly state the current year or acknowledge a knowledge cutoff, but it does mention the effective date of the rules (January 1, 2020) and notes that the threshold is adjusted annually for inflation."
           },
           "weighted_score": 0.9
         }
@@ -71,67 +71,67 @@
       "questions": [
         {
           "question_id": "401k-limits-2026",
-          "response": "The 2026 contribution limits for 401(k) accounts have not been officially announced by the IRS, as the 2026 limits are not yet known. The IRS typically announces the new limits in October or November of each year, for the following year.\n\nHowever, based on the historical trend, we can make an educated estimate. The 2025 contribution limits for 401(k) accounts are:\n\n* Elective deferrals (employee contributions): $20,500\n* Catch-up contributions (for participants 50 and older): $6,500\n\nAssuming a ...",
+          "response": "The 2026 contribution limits for 401(k) accounts have not been officially announced by the IRS, as the 2026 limits are not yet known. The IRS typically announces the new contribution limits for the upcoming year in October or November of the previous year.\n\nHowever, based on the historical trend, the 2026 contribution limits are expected to be announced in the fall of 2025. Here are the 2025 contribution limits for 401(k) accounts:\n\n* Elective deferrals (employee contributions): $19,500\n* Catch-...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The response is partially factually accurate as it provides the correct 2025 contribution limits, but the estimated 2026 limits are not officially confirmed by the IRS. It covers some expected topics like employee contribution limits and catch-up contributions, but misses the topic of employer match. The response demonstrates good recency awareness by acknowledging that the 2026 limits have not been officially announced and providing a clear disclaimer about the estimates."
+            "explanation": "The AI response is factually accurate in stating that the 2026 contribution limits have not been officially announced and provides the correct 2025 limits. However, it does not provide information on the employer match, which is an expected topic, resulting in a lower completeness score. The response demonstrates good recency awareness by acknowledging that the 2026 limits are not yet known and providing a timeframe for when they are typically announced."
           },
           "weighted_score": 0.6
         },
         {
           "question_id": "ira-limits-2026",
-          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts are as follows:\n\n* Traditional IRA:\n\t+ The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n* Roth IRA:\n\t+ The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n\nNote: These limits are subject to change, and it's always a good idea to check with the IRS or a financial advisor for the most up-to-date inf...",
+          "response": "The 2026 contribution limits for Traditional and Roth IRA accounts are as follows:\n\n* Traditional IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n* Roth IRA: The annual contribution limit is $6,000 in 2026, or $7,000 if you are 50 or older (due to the catch-up contribution).\n\nNote: These limits are subject to change, and it's always a good idea to check with the IRS or a financial advisor to confirm the current limits bef...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 1.0,
-            "explanation": "The AI response provides the correct contribution limits for Traditional and Roth IRA accounts in 2026, including catch-up contributions. However, it lacks information on income limits for Roth IRA contributions, which is an expected topic. The response does acknowledge that the information is subject to change and suggests verifying with the IRS, demonstrating good recency awareness."
+            "explanation": "The AI response provides the correct contribution limits for Traditional and Roth IRA accounts in 2026, including catch-up contributions. However, it lacks information on income limits for Roth IRA contributions, which is an important aspect to consider. The response does acknowledge the current year and suggests verifying the information with the IRS, demonstrating good recency awareness."
           },
           "weighted_score": 0.6
         },
         {
           "question_id": "hsa-limits-2026",
-          "response": "The 2026 HSA (Health Savings Account) contribution limits have not been officially announced by the IRS, as they are typically announced in the fall of each year for the upcoming year. However, based on the historical trend, here are the projected 2026 HSA contribution limits:\n\n* Individual coverage: $3,650 (an increase from $3,550 in 2025)\n* Family coverage: $7,300 (an increase from $7,250 in 2025)\n\nThese projected limits are based on the Consumer Price Index (CPI) inflation rate, which is used...",
+          "response": "As of the 2022 Consolidated Appropriations Act, the Health Savings Account (HSA) contribution limits for 2026 are as follows:\n\n* For individuals: $3,550\n* For families: $7,100\n\nThese limits apply to the total amount that can be contributed to an HSA in 2026. Additionally, individuals 55 and older can make an additional \"catch-up\" contribution of $1,000.\n\nPlease note that these limits are subject to change, and it's always a good idea to check with the IRS or a qualified tax professional for the ...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
-            "recency_awareness": 1.0,
-            "explanation": "The AI response provides projected 2026 HSA contribution limits based on historical trends, but notes that these are subject to change and have not been officially announced by the IRS, which affects factual accuracy. The response covers individual and family limits but misses catch-up contributions and HDHP requirements, impacting completeness. However, it correctly acknowledges the current state of knowledge and the need for verification, demonstrating good recency awareness."
+            "recency_awareness": 0.5,
+            "explanation": "The AI response provides some correct information about the 2026 HSA contribution limits, but it references the 2022 Consolidated Appropriations Act, which may not reflect the current limits. The response also misses the topic of HDHP requirements. Additionally, while it mentions that the limits are subject to change and advises checking with the IRS, it does not explicitly state that the information might not be up-to-date for 2026."
           },
-          "weighted_score": 0.6
+          "weighted_score": 0.5
         }
       ],
-      "average_score": 0.6
+      "average_score": 0.567
     },
     "consumer_rights": {
       "questions": [
         {
           "question_id": "credit-report-rights",
-          "response": "You can get a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once every 12 months. This is a federal law, known as the Fair Credit Reporting Act (FCRA), which requires credit reporting agencies to provide you with a free copy of your credit report once a year.\n\nHere's how to get your free credit report:\n\n1. Visit the website of each credit reporting agency:\n\t* Equifax: [www.equifax.com](http://www.equifax.com)\n\t* Experian: [www.exper...",
+          "response": "You can obtain a free credit report from each of the three major credit reporting agencies (Equifax, Experian, and TransUnion) once every 12 months. This is mandated by the Fair Credit Reporting Act (FCRA). Here's how to get your free credit report:\n\n1. **AnnualCreditReport.com**: This is the official website for ordering free credit reports. You can request a free report from each of the three major credit reporting agencies by visiting this website.\n2. **Phone**: You can also order your free c...",
           "scores": {
             "factual_accuracy": 0.5,
             "completeness": 0.5,
             "recency_awareness": 0.0,
-            "explanation": "The response provides some accurate information about obtaining a free credit report from the three major credit reporting agencies, but it does not mention AnnualCreditReport.com, which is the official website for requesting free credit reports. Additionally, it does not cover the topic of weekly access, which is a recent development due to the COVID-19 pandemic, allowing consumers to access their credit reports for free once a week. The response also lacks information about the dispute process. The information provided seems to be outdated, as it does not acknowledge the current year or any recent changes in credit report policies."
+            "explanation": "The AI response provides mostly accurate information about obtaining a free credit report from the three major credit reporting agencies through AnnualCreditReport.com, phone, or mail. However, it does not mention the current weekly access to credit reports due to the COVID-19 pandemic, as stated on the CFPB.gov website. Additionally, it lacks information about the dispute process. The response also does not acknowledge the current year or knowledge cutoff, presenting outdated information without a disclaimer."
           },
           "weighted_score": 0.4
         },
         {
           "question_id": "warranty-rights",
-          "response": "The Magnuson-Moss Warranty Act (15 U.S.C. \u00a7 2301 et seq.) is a federal law that regulates warranties on consumer products. If a product breaks, you may have certain rights under this act. Here are some key provisions:\n\n1. **Written Warranty**: The manufacturer must provide a written warranty that is clear, concise, and easy to understand. The warranty must specify the duration of the warranty, the terms and conditions, and the procedures for making claims.\n2. **Full Warranty**: If the product is...",
+          "response": "The Magnuson-Moss Warranty Act (15 U.S.C. \u00a7 2301 et seq.) is a federal law that regulates warranties and guarantees on consumer products. If a product breaks, you may have certain rights under this act. Here are some key provisions:\n\n1. **Written Warranty**: The manufacturer must provide a written warranty that is clear, concise, and easy to understand. The warranty must specify the duration of the warranty, the terms and conditions of the warranty, and the procedures for making claims.\n2. **Ful...",
           "scores": {
-            "factual_accuracy": 0.9,
-            "completeness": 0.8,
+            "factual_accuracy": 1.0,
+            "completeness": 1.0,
             "recency_awareness": 0.0,
-            "explanation": "The AI response provides mostly accurate information about the Magnuson-Moss Warranty Act, covering key provisions such as written warranty requirements, full and limited warranties, and dispute resolution. However, it does not explicitly mention implied warranty, which is an important aspect of the Act. Additionally, the response does not acknowledge the current year or knowledge cutoff, presenting information without a clear timeframe. Overall, the response demonstrates a good understanding of the topic but lacks completeness and recency awareness."
+            "explanation": "The AI response accurately covers the expected topics, including implied warranty, written warranty requirements, and FTC enforcement, as per the Magnuson-Moss Warranty Act. The information provided is correct and verifiable through the FTC.gov website. However, the response does not acknowledge the current year or knowledge cutoff, which is the only drawback."
           },
-          "weighted_score": 0.69
+          "weighted_score": 0.8
         }
       ],
-      "average_score": 0.545
+      "average_score": 0.6
     }
   },
-  "overall_score": 0.648
+  "overall_score": 0.629
 }


### PR DESCRIPTION
## What

The custom benchmarks — the index's differentiated core — were graded by `llama-3.1-8b-instant`, a weak 8B judge scoring models *including stronger ones*. Switch the judge to Groq **`llama-3.3-70b-versatile`** (still free-tier).

## Why

- **Discrimination:** an 8B grader has weak discrimination on the rubric. Verified the 70B is meaningfully sharper (it flags unannounced future-year tax figures the 8B accepted).
- **Reliability:** the 8B frequently returned unparseable JSON — `"Could not parse judge response"` appears across many committed result files — which silently defaulted to **zero** scores. The 70B returns clean JSON.
- Only the **judge** changes; the models under test stay free-tier 8B assistants. The grader is infrastructure, not a contestant (documented in the README).

Also adds a **bounded Groq retry** (`groq=3`) so a transient TPM rate-limit on a judge call no longer yields a bogus zero — the existing circuit-breaker + capped backoff keep it from running long.

## Validation

`llama-3.3-70b-versatile` confirmed via Groq API: HTTP 200 (free-tier, no billing gate), clean parseable JSON. CI verify run on this branch confirms custom-benchmark scores populate (and fewer/no parse failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)