### PR TITLE
Track results over time: run-health history + rolling score averages

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -210,7 +210,79 @@ class BenchmarkAggregator:
 
                 historical["models"][model_name]["scores"].append(score_entry)
 
+        # Add a trailing-window rolling average per model/benchmark. Single-run scores are
+        # noisy (small samples), so the smoothed series is the more meaningful trend.
+        for model_data in historical["models"].values():
+            model_data["rolling"] = self._rolling_averages(model_data["scores"])
+
         return historical
+
+    @staticmethod
+    def _rolling_averages(scores: list, window: int = 3) -> list:
+        """Trailing-`window` mean per benchmark, computed run-over-run. Null/missing
+        scores are skipped (not treated as 0), so an errored run doesn't drag the trend."""
+        rolling = []
+        for i, entry in enumerate(scores):
+            window_slice = scores[max(0, i - window + 1): i + 1]
+            smoothed = {"date": entry["date"]}
+            for key in entry:
+                if key == "date":
+                    continue
+                vals = [w[key] for w in window_slice if isinstance(w.get(key), (int, float))]
+                if vals:
+                    smoothed[key] = round(sum(vals) / len(vals), 3)
+            rolling.append(smoothed)
+        return rolling
+
+    @staticmethod
+    def _cell_status(bench_data: dict) -> str:
+        """ok if a benchmark produced a real score; error if it failed (API/quota error
+        or a null score)."""
+        if bench_data.get("status") == "error" or bench_data.get("score") is None:
+            return "error"
+        return "ok"
+
+    def build_run_health(self) -> dict:
+        """Per-run health derived from the result files: for each run, which
+        (model, benchmark) cells scored ok vs errored, plus summary counts. Lets us track
+        pipeline degradation over time (e.g. Groq getting rate-limited, Google dropping
+        out) without digging through CI logs. A model absent from a run's `models` list
+        produced no results at all that run."""
+        health = {"last_updated": datetime.now().strftime("%Y-%m-%d"), "runs": []}
+        if not self.results_dir.exists():
+            return health
+
+        date_dirs = sorted(
+            [d for d in self.results_dir.iterdir() if d.is_dir() and d.name[0].isdigit()]
+        )
+        for date_dir in date_dirs:
+            models = self._parse_model_results(date_dir)
+            cells, ok, err = {}, 0, 0
+            for model_name, model_data in models.items():
+                statuses = {}
+                for bench_name, bench_data in model_data.get("benchmarks", {}).items():
+                    status = self._cell_status(bench_data)
+                    statuses[bench_name] = status
+                    if status == "ok":
+                        ok += 1
+                    else:
+                        err += 1
+                cells[model_name] = statuses
+            health["runs"].append({
+                "date": date_dir.name,
+                "models": sorted(cells.keys()),
+                "cells": cells,
+                "summary": {"ok": ok, "error": err, "total": ok + err},
+            })
+        return health
+
+    def save_run_health(self, output_path: str = None) -> str:
+        """Save run-health history."""
+        if output_path is None:
+            output_path = self.results_dir / "run-health.json"
+        with open(output_path, "w") as f:
+            json.dump(self.build_run_health(), f, indent=2)
+        return str(output_path)
 
     def save_latest(self, output_path: str = None) -> str:
         """Save aggregated latest results."""
@@ -244,10 +316,12 @@ class BenchmarkAggregator:
 
         latest_path = self.save_latest(output_dir / "latest.json")
         historical_path = self.save_historical(output_dir / "historical.json")
+        health_path = self.save_run_health(output_dir / "run-health.json")
 
         return {
             "latest": latest_path,
-            "historical": historical_path
+            "historical": historical_path,
+            "run_health": health_path,
         }
 
 
@@ -269,11 +343,14 @@ def main():
         print(f"Exported to frontend:")
         print(f"  Latest: {paths['latest']}")
         print(f"  Historical: {paths['historical']}")
+        print(f"  Run health: {paths['run_health']}")
     else:
         latest_path = aggregator.save_latest()
         historical_path = aggregator.save_historical()
+        health_path = aggregator.save_run_health()
         print(f"Saved latest results: {latest_path}")
         print(f"Saved historical summary: {historical_path}")
+        print(f"Saved run health: {health_path}")
 
     # Print summary
     latest = aggregator.aggregate_latest()

--- a/output/historical.json
+++ b/output/historical.json
@@ -1,18 +1,6 @@
 {
-  "last_updated": "2026-06-29",
+  "last_updated": "2026-06-28",
   "models": {
-    "together/mistral-7b-instruct": {
-      "provider": "together",
-      "tier": "free",
-      "scores": [
-        {
-          "date": "2026-01-15"
-        },
-        {
-          "date": "2026-02-04"
-        }
-      ]
-    },
     "groq/llama-3.1-8b-instant": {
       "provider": "groq",
       "tier": "free",
@@ -25,82 +13,189 @@
         },
         {
           "date": "2026-05-25",
-          "practical_knowledge": 0.555,
-          "creative_technical": 0.413
+          "creative_technical": 0.413,
+          "practical_knowledge": 0.555
         },
         {
           "date": "2026-05-27",
-          "practical_knowledge": 0.314,
-          "creative_technical": 0.237
+          "creative_technical": 0.237,
+          "practical_knowledge": 0.314
         },
         {
           "date": "2026-05-28",
-          "practical_knowledge": 0.369,
-          "creative_technical": 0.393
+          "creative_technical": 0.393,
+          "practical_knowledge": 0.369
         },
         {
           "date": "2026-05-31",
-          "practical_knowledge": 0.421,
-          "creative_technical": 0.624
+          "creative_technical": 0.624,
+          "practical_knowledge": 0.421
         },
         {
           "date": "2026-06-05",
-          "practical_knowledge": 0.427,
-          "creative_technical": 0.736
+          "creative_technical": 0.736,
+          "practical_knowledge": 0.427
         },
         {
           "date": "2026-06-07",
-          "practical_knowledge": 0.484,
-          "creative_technical": 0.38
+          "creative_technical": 0.38,
+          "practical_knowledge": 0.484
         },
         {
           "date": "2026-06-14",
-          "practical_knowledge": 0.397,
-          "creative_technical": 0.5
+          "creative_technical": 0.5,
+          "practical_knowledge": 0.397
         },
         {
           "date": "2026-06-17",
-          "practical_knowledge": 0.525,
-          "creative_technical": 0.47
+          "creative_technical": 0.47,
+          "practical_knowledge": 0.525
         },
         {
           "date": "2026-06-18",
-          "practical_knowledge": 0.477,
           "creative_technical": 0.312,
           "gsm8k": 0.8,
-          "ifeval": 1.0
+          "ifeval": 1.0,
+          "practical_knowledge": 0.477
         },
         {
           "date": "2026-06-21",
-          "practical_knowledge": 0.38,
           "creative_technical": 0.572,
-          "gsm8k": 0.6
+          "gsm8k": 0.6,
+          "practical_knowledge": 0.38
         },
         {
           "date": "2026-06-22",
-          "practical_knowledge": 0.511,
           "creative_technical": 0.48,
-          "gsm8k": 0.667
+          "gsm8k": 0.667,
+          "practical_knowledge": 0.511
         },
         {
           "date": "2026-06-25",
-          "practical_knowledge": 0.413,
           "creative_technical": 0.428,
-          "gsm8k": 0.6
+          "gsm8k": 0.6,
+          "practical_knowledge": 0.413
         },
         {
           "date": "2026-06-28",
-          "practical_knowledge": 0.495,
           "creative_technical": 0.548,
           "gsm8k": 0.667,
-          "ifeval": 0.667
+          "ifeval": 0.667,
+          "practical_knowledge": 0.495
         },
         {
           "date": "2026-06-29",
-          "practical_knowledge": 0.47,
           "creative_technical": 0.513,
           "gsm8k": 0.667,
-          "ifeval": 1.0
+          "ifeval": 1.0,
+          "practical_knowledge": 0.47
+        }
+      ],
+      "rolling": [
+        {
+          "date": "2026-01-15"
+        },
+        {
+          "date": "2026-02-04"
+        },
+        {
+          "date": "2026-05-25",
+          "creative_technical": 0.413,
+          "practical_knowledge": 0.555
+        },
+        {
+          "date": "2026-05-27",
+          "creative_technical": 0.325,
+          "practical_knowledge": 0.434
+        },
+        {
+          "date": "2026-05-28",
+          "creative_technical": 0.348,
+          "practical_knowledge": 0.413
+        },
+        {
+          "date": "2026-05-31",
+          "creative_technical": 0.418,
+          "practical_knowledge": 0.368
+        },
+        {
+          "date": "2026-06-05",
+          "creative_technical": 0.584,
+          "practical_knowledge": 0.406
+        },
+        {
+          "date": "2026-06-07",
+          "creative_technical": 0.58,
+          "practical_knowledge": 0.444
+        },
+        {
+          "date": "2026-06-14",
+          "creative_technical": 0.539,
+          "practical_knowledge": 0.436
+        },
+        {
+          "date": "2026-06-17",
+          "creative_technical": 0.45,
+          "practical_knowledge": 0.469
+        },
+        {
+          "date": "2026-06-18",
+          "creative_technical": 0.427,
+          "gsm8k": 0.8,
+          "ifeval": 1.0,
+          "practical_knowledge": 0.466
+        },
+        {
+          "date": "2026-06-21",
+          "creative_technical": 0.451,
+          "gsm8k": 0.7,
+          "practical_knowledge": 0.461
+        },
+        {
+          "date": "2026-06-22",
+          "creative_technical": 0.455,
+          "gsm8k": 0.689,
+          "practical_knowledge": 0.456
+        },
+        {
+          "date": "2026-06-25",
+          "creative_technical": 0.493,
+          "gsm8k": 0.622,
+          "practical_knowledge": 0.435
+        },
+        {
+          "date": "2026-06-28",
+          "creative_technical": 0.485,
+          "gsm8k": 0.645,
+          "ifeval": 0.667,
+          "practical_knowledge": 0.473
+        },
+        {
+          "date": "2026-06-29",
+          "creative_technical": 0.496,
+          "gsm8k": 0.645,
+          "ifeval": 0.834,
+          "practical_knowledge": 0.459
+        }
+      ]
+    },
+    "together/mistral-7b-instruct": {
+      "provider": "together",
+      "tier": "free",
+      "scores": [
+        {
+          "date": "2026-01-15"
+        },
+        {
+          "date": "2026-02-04"
+        }
+      ],
+      "rolling": [
+        {
+          "date": "2026-01-15"
+        },
+        {
+          "date": "2026-02-04"
         }
       ]
     },
@@ -111,12 +206,8 @@
         {
           "date": "2026-02-04"
         }
-      ]
-    },
-    "huggingface/mistral-7b-instruct": {
-      "provider": "huggingface",
-      "tier": "free",
-      "scores": [
+      ],
+      "rolling": [
         {
           "date": "2026-02-04"
         }
@@ -129,26 +220,202 @@
         {
           "date": "2026-02-04"
         }
+      ],
+      "rolling": [
+        {
+          "date": "2026-02-04"
+        }
       ]
     },
-    "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
-      "provider": "together",
+    "huggingface/mistral-7b-instruct": {
+      "provider": "huggingface",
+      "tier": "free",
+      "scores": [
+        {
+          "date": "2026-02-04"
+        }
+      ],
+      "rolling": [
+        {
+          "date": "2026-02-04"
+        }
+      ]
+    },
+    "cohere/command-r-08-2024": {
+      "provider": "cohere",
       "tier": "free",
       "scores": [
         {
           "date": "2026-05-27",
-          "practical_knowledge": null,
-          "creative_technical": null
+          "creative_technical": 0.51,
+          "practical_knowledge": 0.459
         },
         {
           "date": "2026-05-28",
-          "practical_knowledge": null,
-          "creative_technical": null
+          "creative_technical": 0.577,
+          "practical_knowledge": 0.536
         },
         {
           "date": "2026-05-31",
-          "practical_knowledge": null,
-          "creative_technical": null
+          "creative_technical": 0.276,
+          "practical_knowledge": 0.411
+        },
+        {
+          "date": "2026-06-05",
+          "creative_technical": 0.578,
+          "practical_knowledge": 0.516
+        },
+        {
+          "date": "2026-06-07",
+          "creative_technical": 0.428,
+          "practical_knowledge": 0.534
+        },
+        {
+          "date": "2026-06-14",
+          "creative_technical": 0.452,
+          "practical_knowledge": 0.562
+        },
+        {
+          "date": "2026-06-17",
+          "creative_technical": 0.765,
+          "practical_knowledge": 0.59
+        },
+        {
+          "date": "2026-06-18",
+          "creative_technical": 0.452,
+          "practical_knowledge": 0.5
+        },
+        {
+          "date": "2026-06-21",
+          "creative_technical": 0.396,
+          "practical_knowledge": 0.471
+        },
+        {
+          "date": "2026-06-22",
+          "creative_technical": 0.537,
+          "practical_knowledge": 0.5
+        },
+        {
+          "date": "2026-06-25",
+          "creative_technical": 0.484,
+          "practical_knowledge": 0.55
+        },
+        {
+          "date": "2026-06-28",
+          "creative_technical": 0.65,
+          "gsm8k": 1.0,
+          "ifeval": 0.333,
+          "practical_knowledge": 0.593
+        },
+        {
+          "date": "2026-06-29",
+          "creative_technical": 0.69,
+          "gsm8k": 1.0,
+          "ifeval": 0.333,
+          "practical_knowledge": 0.5
+        }
+      ],
+      "rolling": [
+        {
+          "date": "2026-05-27",
+          "creative_technical": 0.51,
+          "practical_knowledge": 0.459
+        },
+        {
+          "date": "2026-05-28",
+          "creative_technical": 0.543,
+          "practical_knowledge": 0.498
+        },
+        {
+          "date": "2026-05-31",
+          "creative_technical": 0.454,
+          "practical_knowledge": 0.469
+        },
+        {
+          "date": "2026-06-05",
+          "creative_technical": 0.477,
+          "practical_knowledge": 0.488
+        },
+        {
+          "date": "2026-06-07",
+          "creative_technical": 0.427,
+          "practical_knowledge": 0.487
+        },
+        {
+          "date": "2026-06-14",
+          "creative_technical": 0.486,
+          "practical_knowledge": 0.537
+        },
+        {
+          "date": "2026-06-17",
+          "creative_technical": 0.548,
+          "practical_knowledge": 0.562
+        },
+        {
+          "date": "2026-06-18",
+          "creative_technical": 0.556,
+          "practical_knowledge": 0.551
+        },
+        {
+          "date": "2026-06-21",
+          "creative_technical": 0.538,
+          "practical_knowledge": 0.52
+        },
+        {
+          "date": "2026-06-22",
+          "creative_technical": 0.462,
+          "practical_knowledge": 0.49
+        },
+        {
+          "date": "2026-06-25",
+          "creative_technical": 0.472,
+          "practical_knowledge": 0.507
+        },
+        {
+          "date": "2026-06-28",
+          "creative_technical": 0.557,
+          "gsm8k": 1.0,
+          "ifeval": 0.333,
+          "practical_knowledge": 0.548
+        },
+        {
+          "date": "2026-06-29",
+          "creative_technical": 0.608,
+          "gsm8k": 1.0,
+          "ifeval": 0.333,
+          "practical_knowledge": 0.548
+        }
+      ]
+    },
+    "google/gemini-2.0-flash": {
+      "provider": "google",
+      "tier": "free",
+      "scores": [
+        {
+          "date": "2026-05-27",
+          "creative_technical": null,
+          "practical_knowledge": null
+        },
+        {
+          "date": "2026-05-28",
+          "creative_technical": null,
+          "practical_knowledge": null
+        },
+        {
+          "date": "2026-05-31",
+          "creative_technical": null,
+          "practical_knowledge": null
+        }
+      ],
+      "rolling": [
+        {
+          "date": "2026-05-27"
+        },
+        {
+          "date": "2026-05-28"
+        },
+        {
+          "date": "2026-05-31"
         }
       ]
     },
@@ -221,85 +488,77 @@
           "creative_technical": 0.513,
           "practical_knowledge": 0.5
         }
-      ]
-    },
-    "cohere/command-r-08-2024": {
-      "provider": "cohere",
-      "tier": "free",
-      "scores": [
+      ],
+      "rolling": [
         {
           "date": "2026-05-27",
-          "creative_technical": 0.51,
-          "practical_knowledge": 0.459
+          "creative_technical": 0.273,
+          "practical_knowledge": 0.502
         },
         {
           "date": "2026-05-28",
-          "creative_technical": 0.577,
-          "practical_knowledge": 0.536
+          "creative_technical": 0.333,
+          "practical_knowledge": 0.485
         },
         {
           "date": "2026-05-31",
-          "creative_technical": 0.276,
-          "practical_knowledge": 0.411
+          "creative_technical": 0.396,
+          "practical_knowledge": 0.467
         },
         {
           "date": "2026-06-05",
-          "creative_technical": 0.578,
-          "practical_knowledge": 0.516
+          "creative_technical": 0.438,
+          "practical_knowledge": 0.435
         },
         {
           "date": "2026-06-07",
-          "creative_technical": 0.428,
-          "practical_knowledge": 0.534
+          "creative_technical": 0.463,
+          "practical_knowledge": 0.436
         },
         {
           "date": "2026-06-14",
-          "creative_technical": 0.452,
-          "practical_knowledge": 0.562
+          "creative_technical": 0.415,
+          "practical_knowledge": 0.454
         },
         {
           "date": "2026-06-17",
-          "creative_technical": 0.765,
-          "practical_knowledge": 0.59
+          "creative_technical": 0.4,
+          "practical_knowledge": 0.506
         },
         {
           "date": "2026-06-18",
-          "creative_technical": 0.452,
-          "practical_knowledge": 0.5
+          "creative_technical": 0.387,
+          "practical_knowledge": 0.507
         },
         {
           "date": "2026-06-21",
-          "creative_technical": 0.396,
-          "practical_knowledge": 0.471
+          "creative_technical": 0.416,
+          "practical_knowledge": 0.508
         },
         {
           "date": "2026-06-22",
-          "creative_technical": 0.537,
-          "practical_knowledge": 0.5
+          "creative_technical": 0.388,
+          "practical_knowledge": 0.482
         },
         {
           "date": "2026-06-25",
-          "creative_technical": 0.484,
-          "practical_knowledge": 0.55
+          "creative_technical": 0.383,
+          "practical_knowledge": 0.455
         },
         {
           "date": "2026-06-28",
-          "creative_technical": 0.65,
-          "ifeval": 0.333,
-          "gsm8k": 1.0,
-          "practical_knowledge": 0.593
+          "creative_technical": 0.394,
+          "practical_knowledge": 0.502
         },
         {
           "date": "2026-06-29",
-          "creative_technical": 0.69,
-          "ifeval": 0.333,
-          "gsm8k": 1.0,
-          "practical_knowledge": 0.5
+          "creative_technical": 0.474,
+          "practical_knowledge": 0.508
         }
       ]
     },
-    "google/gemini-2.0-flash": {
-      "provider": "google",
+    "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+      "provider": "together",
       "tier": "free",
       "scores": [
         {
@@ -316,6 +575,17 @@
           "date": "2026-05-31",
           "creative_technical": null,
           "practical_knowledge": null
+        }
+      ],
+      "rolling": [
+        {
+          "date": "2026-05-27"
+        },
+        {
+          "date": "2026-05-28"
+        },
+        {
+          "date": "2026-05-31"
         }
       ]
     },
@@ -372,6 +642,58 @@
           "date": "2026-06-29",
           "creative_technical": null,
           "practical_knowledge": null
+        }
+      ],
+      "rolling": [
+        {
+          "date": "2026-06-05",
+          "creative_technical": 0.03,
+          "practical_knowledge": 0.325
+        },
+        {
+          "date": "2026-06-07",
+          "creative_technical": 0.015,
+          "practical_knowledge": 0.275
+        },
+        {
+          "date": "2026-06-14",
+          "creative_technical": 0.047,
+          "practical_knowledge": 0.26
+        },
+        {
+          "date": "2026-06-17",
+          "creative_technical": 0.037,
+          "practical_knowledge": 0.253
+        },
+        {
+          "date": "2026-06-18",
+          "creative_technical": 0.056,
+          "practical_knowledge": 0.268
+        },
+        {
+          "date": "2026-06-21",
+          "creative_technical": 0.015,
+          "practical_knowledge": 0.325
+        },
+        {
+          "date": "2026-06-22",
+          "creative_technical": 0.168,
+          "practical_knowledge": 0.369
+        },
+        {
+          "date": "2026-06-25",
+          "creative_technical": 0.112,
+          "practical_knowledge": 0.386
+        },
+        {
+          "date": "2026-06-28",
+          "creative_technical": 0.153,
+          "practical_knowledge": 0.407
+        },
+        {
+          "date": "2026-06-29",
+          "creative_technical": 0.0,
+          "practical_knowledge": 0.419
         }
       ]
     }

--- a/output/run-health.json
+++ b/output/run-health.json
@@ -1,0 +1,504 @@
+{
+  "last_updated": "2026-06-28",
+  "runs": [
+    {
+      "date": "2026-01-15",
+      "models": [
+        "groq/llama-3.1-8b-instant",
+        "together/mistral-7b-instruct"
+      ],
+      "cells": {
+        "groq/llama-3.1-8b-instant": {},
+        "together/mistral-7b-instruct": {}
+      },
+      "summary": {
+        "ok": 0,
+        "error": 0,
+        "total": 0
+      }
+    },
+    {
+      "date": "2026-02-04",
+      "models": [
+        "cohere/command-light",
+        "google/gemini-1.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/mistral-7b-instruct",
+        "together/mistral-7b-instruct"
+      ],
+      "cells": {
+        "cohere/command-light": {},
+        "google/gemini-1.5-flash": {},
+        "groq/llama-3.1-8b-instant": {},
+        "huggingface/mistral-7b-instruct": {},
+        "together/mistral-7b-instruct": {}
+      },
+      "summary": {
+        "ok": 0,
+        "error": 0,
+        "total": 0
+      }
+    },
+    {
+      "date": "2026-05-25",
+      "models": [
+        "groq/llama-3.1-8b-instant"
+      ],
+      "cells": {
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 2,
+        "error": 0,
+        "total": 2
+      }
+    },
+    {
+      "date": "2026-05-27",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.0-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
+        "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.0-flash": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        }
+      },
+      "summary": {
+        "ok": 6,
+        "error": 4,
+        "total": 10
+      }
+    },
+    {
+      "date": "2026-05-28",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.0-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
+        "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.0-flash": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        }
+      },
+      "summary": {
+        "ok": 6,
+        "error": 4,
+        "total": 10
+      }
+    },
+    {
+      "date": "2026-05-31",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.0-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct",
+        "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.0-flash": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "together/meta-llama/Llama-3.3-70B-Instruct-Turbo-Free": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        }
+      },
+      "summary": {
+        "ok": 6,
+        "error": 4,
+        "total": 10
+      }
+    },
+    {
+      "date": "2026-06-05",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 8,
+        "error": 0,
+        "total": 8
+      }
+    },
+    {
+      "date": "2026-06-07",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 8,
+        "error": 0,
+        "total": 8
+      }
+    },
+    {
+      "date": "2026-06-14",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 8,
+        "error": 0,
+        "total": 8
+      }
+    },
+    {
+      "date": "2026-06-17",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 8,
+        "error": 0,
+        "total": 8
+      }
+    },
+    {
+      "date": "2026-06-18",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "ifeval": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 8,
+        "error": 2,
+        "total": 10
+      }
+    },
+    {
+      "date": "2026-06-21",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 9,
+        "error": 0,
+        "total": 9
+      }
+    },
+    {
+      "date": "2026-06-22",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 9,
+        "error": 0,
+        "total": 9
+      }
+    },
+    {
+      "date": "2026-06-25",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 9,
+        "error": 0,
+        "total": 9
+      }
+    },
+    {
+      "date": "2026-06-28",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "ifeval": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "ifeval": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 10,
+        "error": 2,
+        "total": 12
+      }
+    },
+    {
+      "date": "2026-06-29",
+      "models": [
+        "cohere/command-r-08-2024",
+        "google/gemini-2.5-flash",
+        "groq/llama-3.1-8b-instant",
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct"
+      ],
+      "cells": {
+        "cohere/command-r-08-2024": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "ifeval": "ok",
+          "practical_knowledge": "ok"
+        },
+        "google/gemini-2.5-flash": {
+          "creative_technical": "error",
+          "practical_knowledge": "error"
+        },
+        "groq/llama-3.1-8b-instant": {
+          "creative_technical": "ok",
+          "gsm8k": "ok",
+          "ifeval": "ok",
+          "practical_knowledge": "ok"
+        },
+        "huggingface/meta-llama/Meta-Llama-3-8B-Instruct": {
+          "creative_technical": "ok",
+          "practical_knowledge": "ok"
+        }
+      },
+      "summary": {
+        "ok": 10,
+        "error": 2,
+        "total": 12
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds two result-tracking capabilities to `aggregate.py` (per the "track results over time" ask):

**1. Run-health history (`output/run-health.json`)** — per dated run, which (model, benchmark) cells scored `ok` vs `error`, plus summary counts. Surfaces pipeline degradation run-over-run (e.g. Gemini quota misses on 2026-06-28/29, Groq blanking) without digging through CI logs.

**2. Rolling score averages** — `historical.json` now carries a `rolling` series alongside raw `scores`: a trailing-3-run mean per model/benchmark that skips null/errored runs. Single-run scores are small-sample noisy; the smoothed series is the meaningful trend (e.g. groq pk `0.511/0.413/0.495/0.47` → `0.456/0.435/0.473/0.459`).

Pure-Python over committed results (no deps, no API), regenerated each run and committed by the existing workflow step. Backfilled from the full 16-run history in this commit. Validated locally against the real results.

Frontend display (a health view / smoothed sparklines) is a possible follow-up; this lands the data layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)