### PR TITLE
Stamp results with methodology version + provenance

### DIFF
--- a/METHODOLOGY_CHANGELOG.md
+++ b/METHODOLOGY_CHANGELOG.md
@@ -1,0 +1,22 @@
+# Methodology Changelog
+
+Tracks changes to the benchmark **methodology** that affect score comparability —
+separate from the code's version/git tags. The current methodology version lives in
+[`benchmarks/provenance.py`](./benchmarks/provenance.py) (`METHODOLOGY_VERSION`) and is
+stamped into every result file and the aggregated `output/` data.
+
+**Rule:** bump the version whenever a change makes new scores **non-comparable** to prior
+runs — new or changed prompts, a scoring-rubric change, a different judge model, or a
+change in sample selection. Never silently re-score under an existing version.
+
+## 1.0 — 2026-07-02
+
+First versioned methodology. Baseline as of this date:
+
+- **Benchmarks (4):** `practical_knowledge` + `creative_technical` (custom, LLM-as-judge)
+  and `ifeval` + `gsm8k` (via openbench). Openbench benchmarks run on Groq + Cohere;
+  custom benchmarks run on all free-tier providers.
+- **Judge:** Groq `llama-3.3-70b-versatile` (stronger than the models under test).
+- **Sampling:** small (default 3 samples/benchmark) — scores are directional, not precise.
+- Result files and aggregated output now record `methodology_version`, `git_commit`, and
+  run params.

--- a/aggregate.py
+++ b/aggregate.py
@@ -73,8 +73,13 @@ class BenchmarkAggregator:
                         "provider": self._infer_provider(model),
                         "tier": "free",
                         "date": date_dir.name,
+                        "methodology_version": data.get("methodology_version"),
+                        "git_commit": data.get("git_commit"),
                         "benchmarks": {}
                     }
+                # Backfill provenance if the first file for this model lacked it.
+                if models[model].get("methodology_version") is None:
+                    models[model]["methodology_version"] = data.get("methodology_version")
 
                 # Determine benchmark type from filename or content
                 if "practical-knowledge" in result_file.name:
@@ -205,6 +210,8 @@ class BenchmarkAggregator:
 
                 # Add score entry for this date
                 score_entry = {"date": date_dir.name}
+                if model_data.get("methodology_version") is not None:
+                    score_entry["methodology_version"] = model_data["methodology_version"]
                 for bench_name, bench_data in model_data.get("benchmarks", {}).items():
                     score_entry[bench_name] = bench_data.get("score", 0)
 

--- a/benchmarks/creative-technical/eval.py
+++ b/benchmarks/creative-technical/eval.py
@@ -17,6 +17,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from providers import call_llm, provider_api_key, ProviderError  # noqa: E402
+from provenance import provenance  # noqa: E402
 
 
 class CreativeTechnicalEvaluator:
@@ -171,6 +172,7 @@ Respond in JSON format:
             "challenges": [],
             "overall_score": 0.0
         }
+        results.update(provenance(limit=limit, judge_model=self.judge_model))
 
         all_scores = []
         prompts_to_eval = self.prompts["prompts"][:limit] if limit else self.prompts["prompts"]

--- a/benchmarks/openbench/run.py
+++ b/benchmarks/openbench/run.py
@@ -22,6 +22,9 @@ import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from provenance import provenance  # noqa: E402
 from typing import Optional
 
 # HumanEval is intentionally omitted: grading it means executing model-generated code
@@ -134,6 +137,7 @@ def run_benchmark(name: str, provider: str, model: str, limit: int, results_dir:
         BENCHMARKS[name]["extra_field"]: round(score, 3),
         "timestamp": datetime.now().isoformat(),
     }
+    output.update(provenance(limit=limit))
 
     sanitized = model.replace("/", "-").replace(":", "-")
     output_path = results_dir / f"{name}-{provider}-{sanitized}.json"

--- a/benchmarks/practical-knowledge/eval.py
+++ b/benchmarks/practical-knowledge/eval.py
@@ -15,6 +15,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from providers import call_llm, provider_api_key, ProviderError  # noqa: E402
+from provenance import provenance  # noqa: E402
 
 
 class PracticalKnowledgeEvaluator:
@@ -100,6 +101,7 @@ Respond in JSON format:
             "categories": {},
             "overall_score": 0.0
         }
+        results.update(provenance(limit=limit, judge_model=self.judge_model))
 
         all_scores = []
 

--- a/benchmarks/provenance.py
+++ b/benchmarks/provenance.py
@@ -1,0 +1,40 @@
+"""Provenance stamping for benchmark result files.
+
+Every result JSON records the methodology version + code commit + run params so scores
+stay comparable over time and non-comparable runs can be told apart.
+
+METHODOLOGY_VERSION must be bumped whenever a change makes new scores NON-comparable to
+old ones — new/changed prompts, a scoring-rubric change, a different judge model, or a
+change in sample selection. Never silently re-score under the same version. Record every
+bump in METHODOLOGY_CHANGELOG.md. (This is separate from the code's SemVer / git tags.)
+"""
+import os
+import subprocess
+
+METHODOLOGY_VERSION = "1.0"
+
+
+def _git_commit() -> str:
+    """Best-effort short commit hash: CI env first, then local git, else 'unknown'."""
+    sha = os.environ.get("GITHUB_SHA")
+    if sha:
+        return sha[:12]
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def provenance(**extra) -> dict:
+    """A provenance block to merge into a result record. `extra` fields with a value of
+    None are dropped (e.g. an omitted --limit means a full run)."""
+    block = {
+        "methodology_version": METHODOLOGY_VERSION,
+        "git_commit": _git_commit(),
+    }
+    block.update({k: v for k, v in extra.items() if v is not None})
+    return block


### PR DESCRIPTION
Keeps small-sample scores comparable over time and makes non-comparable runs distinguishable.

- `benchmarks/provenance.py` — single source of truth: `METHODOLOGY_VERSION` (1.0) + `provenance()` (methodology_version, git_commit, run params).
- Custom evals + openbench runner stamp every result file (methodology_version, git_commit, limit, judge_model).
- `aggregate.py` propagates methodology_version + git_commit into `output/latest.json` and per-date historical entries. Old unstamped runs read as null.
- `METHODOLOGY_CHANGELOG.md` documents v1.0 + the bump rule.

Additive to the output schema (frontend ignores unknown fields). Validated locally: clean imports + aggregate stamps output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)