### PR TITLE
Add project GitHub Pages site (React port of the leaderboard)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,51 @@
+name: Deploy site
+
+# Rebuild the project's GitHub Pages leaderboard whenever the site code changes or a new
+# weekly benchmark run commits fresh data to output/.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "output/**"
+      - ".github/workflows/deploy-site.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install
+        working-directory: site
+        run: npm ci
+      - name: Build (copies output/ into the site, then vite build)
+        working-directory: site
+        run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+public/data/

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Egg Index — free-tier LLM benchmark</title>
+    <meta
+      name="description"
+      content="Benchmarking free-tier LLMs on tasks regular people actually care about — updated weekly. Open source."
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,0 +1,1618 @@
+{
+  "name": "ai-egg-index-site",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-egg-index-site",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "typescript": "^5.5.4",
+        "vite": "^5.4.8"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.41",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.41.tgz",
+      "integrity": "sha512-WwS7MHhqGHHlaVsqRZnhvCEMS0owDX+SxRlve7JkuH7My1Ara3ZriTmCQupPfYjxMZ8I/tgxtJYr2t7taHaH4A==",
+      "dev": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.385",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.385.tgz",
+      "integrity": "sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    }
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ai-egg-index-site",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "predev": "node scripts/copy-data.mjs",
+    "dev": "vite",
+    "prebuild": "node scripts/copy-data.mjs",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.8"
+  }
+}

--- a/site/scripts/copy-data.mjs
+++ b/site/scripts/copy-data.mjs
@@ -1,0 +1,21 @@
+// Copy the repo's aggregated output JSON into the site's public/data so the built site
+// serves its own benchmark data. Run automatically before dev/build (see package.json).
+import { mkdirSync, copyFileSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outputDir = join(here, '..', '..', 'output'); // <repo>/output
+const dataDir = join(here, '..', 'public', 'data'); // <repo>/site/public/data
+
+mkdirSync(dataDir, { recursive: true });
+
+for (const file of ['latest.json', 'historical.json', 'run-health.json']) {
+  const src = join(outputDir, file);
+  if (existsSync(src)) {
+    copyFileSync(src, join(dataDir, file));
+    console.log(`[copy-data] ${file}`);
+  } else {
+    console.warn(`[copy-data] missing ${file} — site will 404 on it`);
+  }
+}

--- a/site/src/BenchmarkPage.css
+++ b/site/src/BenchmarkPage.css
@@ -1,0 +1,538 @@
+.benchmark-page {
+  min-height: 100vh;
+  background: var(--bg-primary);
+  padding: 2rem;
+}
+
+.benchmark-page-container {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.back-link {
+  display: inline-block;
+  color: var(--accent-cyan);
+  text-decoration: none;
+  margin-bottom: 2rem;
+  font-size: 0.95rem;
+  transition: color 0.2s ease;
+}
+
+.back-link:hover {
+  color: var(--accent-teal);
+}
+
+.benchmark-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.benchmark-header h1 {
+  font-size: 3rem;
+  background: linear-gradient(135deg, var(--accent-cyan), var(--accent-teal));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin: 0 0 1rem 0;
+}
+
+.benchmark-tagline {
+  font-size: 1.3rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.benchmark-why-name {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  max-width: 500px;
+  margin: 1rem auto 0;
+  font-style: italic;
+}
+
+.benchmark-intro {
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  padding: 2rem;
+  margin-bottom: 3rem;
+  border-left: 4px solid var(--accent-cyan);
+}
+
+.intro-content h2 {
+  color: var(--text-primary);
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.intro-content p {
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+.intro-content p:last-child {
+  margin-bottom: 0;
+}
+
+/* Landscape / Comparison Section */
+.benchmark-landscape {
+  margin-bottom: 3rem;
+}
+
+.benchmark-landscape h2 {
+  color: var(--text-primary);
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.landscape-intro {
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.comparison-table-wrapper {
+  overflow-x: auto;
+  margin-bottom: 2rem;
+}
+
+.comparison-table {
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.comparison-table th {
+  color: var(--text-primary);
+  font-weight: 600;
+  background: var(--bg-secondary);
+}
+
+.comparison-table td {
+  color: var(--text-secondary);
+}
+
+.comparison-table a {
+  color: var(--accent-cyan);
+  text-decoration: none;
+}
+
+.comparison-table a:hover {
+  text-decoration: underline;
+}
+
+.comparison-table .cell-yes {
+  color: #10b981;
+}
+
+.comparison-table .cell-no {
+  color: #888;
+}
+
+.comparison-table .cell-partial {
+  color: #fbbf24;
+}
+
+.comparison-table .highlight-row {
+  background: rgba(6, 182, 212, 0.1);
+}
+
+.comparison-table .highlight-row td {
+  color: var(--text-primary);
+}
+
+.differentiators {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.diff-card {
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  padding: 1.5rem;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.diff-icon {
+  font-size: 2rem;
+  display: block;
+  margin-bottom: 0.75rem;
+}
+
+.diff-card h4 {
+  color: var(--accent-cyan);
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.diff-card p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.benchmark-categories {
+  margin-bottom: 3rem;
+}
+
+.benchmark-categories h2 {
+  color: var(--text-primary);
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.category-card {
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.category-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(6, 182, 212, 0.3);
+}
+
+.category-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.category-card.custom .category-badge {
+  background: rgba(6, 182, 212, 0.2);
+  color: var(--accent-cyan);
+}
+
+.category-card.openbench .category-badge {
+  background: rgba(167, 139, 250, 0.2);
+  color: #a78bfa;
+}
+
+.category-card h3 {
+  color: var(--text-primary);
+  font-size: 1.2rem;
+  margin-bottom: 0.75rem;
+}
+
+.category-card p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.benchmark-results {
+  margin-bottom: 3rem;
+}
+
+.benchmark-results h2 {
+  color: var(--text-primary);
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.last-updated {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 0.25rem;
+}
+
+.sample-caveat {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-style: italic;
+  margin-bottom: 1.5rem;
+}
+
+/* Banner dropdown nav (Rankings / About / Details / History) */
+.benchmark-nav {
+  position: relative;
+  display: inline-block;
+  margin-top: 1.25rem;
+}
+
+.benchmark-nav-toggle {
+  background: rgba(6, 182, 212, 0.12);
+  border: 1px solid var(--accent-cyan, #06b6d4);
+  color: var(--accent-cyan, #06b6d4);
+  padding: 0.5rem 1.1rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.benchmark-nav-toggle:hover {
+  background: rgba(6, 182, 212, 0.2);
+}
+
+.nav-caret {
+  font-size: 0.8rem;
+  margin-left: 0.35rem;
+}
+
+.benchmark-nav-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  list-style: none;
+  margin: 0;
+  padding: 0.35rem;
+  background: var(--card-bg, #0f2942);
+  border: 1px solid rgba(6, 182, 212, 0.35);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 20;
+  min-width: 9rem;
+}
+
+.benchmark-nav-menu li button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text-primary, #e2e8f0);
+  padding: 0.5rem 0.85rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.benchmark-nav-menu li button:hover {
+  background: rgba(6, 182, 212, 0.15);
+}
+
+.benchmark-nav-menu li button.active {
+  color: var(--accent-cyan, #06b6d4);
+  font-weight: 700;
+}
+
+.benchmark-history .history-intro {
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 1.5rem;
+}
+
+.loading-state,
+.error-state {
+  text-align: center;
+  padding: 3rem;
+  background: var(--bg-secondary);
+  border-radius: 12px;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(6, 182, 212, 0.3);
+  border-top-color: var(--accent-cyan);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1rem;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.loading-state p,
+.error-state p {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.error-hint {
+  font-size: 0.9rem;
+  color: var(--text-muted) !important;
+  margin-top: 0.5rem !important;
+}
+
+.benchmark-methodology {
+  margin-bottom: 3rem;
+}
+
+.benchmark-methodology h2 {
+  color: var(--text-primary);
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.methodology-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.methodology-card {
+  background: var(--bg-secondary);
+  border-radius: 12px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.methodology-card h3 {
+  color: var(--accent-cyan);
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.methodology-card p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.github-repo-link {
+  display: inline-block;
+  margin-top: 0.75rem;
+  color: var(--accent-cyan);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.github-repo-link:hover {
+  color: var(--accent-teal);
+}
+
+.benchmark-providers {
+  margin-bottom: 3rem;
+}
+
+.benchmark-providers h2 {
+  color: var(--text-primary);
+  font-size: 1.8rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.provider-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.provider-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--bg-secondary);
+  border-radius: 8px;
+  padding: 0.75rem 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.provider-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.provider-name.groq {
+  color: #fbbf24;
+}
+
+.provider-name.together {
+  color: #a78bfa;
+}
+
+.provider-name.google {
+  color: #34a853;
+}
+
+.provider-name.cohere {
+  color: #ec4899;
+}
+
+.provider-name.huggingface {
+  color: #ffd500;
+}
+
+.provider-limit {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+  .benchmark-page {
+    padding: 1rem;
+  }
+
+  .benchmark-header h1 {
+    font-size: 2rem;
+  }
+
+  .benchmark-tagline {
+    font-size: 1.1rem;
+  }
+
+  .benchmark-intro {
+    padding: 1.5rem;
+  }
+
+  .intro-content p {
+    font-size: 1rem;
+  }
+
+  .category-grid,
+  .methodology-grid,
+  .differentiators {
+    grid-template-columns: 1fr;
+  }
+
+  .comparison-table {
+    font-size: 0.85rem;
+  }
+
+  .comparison-table th,
+  .comparison-table td {
+    padding: 0.75rem 0.5rem;
+  }
+
+  .benchmark-landscape h2,
+  .benchmark-categories h2,
+  .benchmark-results h2,
+  .benchmark-methodology h2,
+  .benchmark-providers h2 {
+    font-size: 1.5rem;
+  }
+}

--- a/site/src/BenchmarkPage.tsx
+++ b/site/src/BenchmarkPage.tsx
@@ -1,0 +1,401 @@
+import React, { useState, useEffect } from 'react';
+import BenchmarkComparer from './components/BenchmarkComparer';
+import PerformanceTrend from './components/PerformanceTrend';
+import PipelineHealth from './components/PipelineHealth';
+import { BenchmarkData, HistoricalData, RunHealth } from './types';
+import { loadBenchmarkFile } from './loadBenchmarkData';
+import './BenchmarkPage.css';
+
+type View = 'rankings' | 'about' | 'details' | 'history';
+
+const VIEW_LABELS: Record<View, string> = {
+  rankings: 'Rankings',
+  about: 'About',
+  details: 'Details',
+  history: 'History',
+};
+
+const BenchmarkPage: React.FC = () => {
+  const [benchmarkData, setBenchmarkData] = useState<BenchmarkData | null>(null);
+  const [historicalData, setHistoricalData] = useState<HistoricalData | null>(null);
+  const [runHealth, setRunHealth] = useState<RunHealth | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // The active view is driven by the `?view=` query param so it can be deep-linked
+  // (e.g. from the header dropdown). Falls back to 'rankings' when absent/invalid.
+  const initialParam =
+    typeof window !== 'undefined'
+      ? new URLSearchParams(window.location.search).get('view')
+      : null;
+  const initialView: View =
+    initialParam && initialParam in VIEW_LABELS ? (initialParam as View) : 'rankings';
+  const [view, setViewState] = useState<View>(initialView);
+  const setView = (v: View) => {
+    setViewState(v);
+    const params = new URLSearchParams(window.location.search);
+    if (v === 'rankings') params.delete('view');
+    else params.set('view', v);
+    const qs = params.toString();
+    window.history.replaceState(
+      null,
+      '',
+      qs ? `?${qs}${window.location.hash}` : window.location.pathname,
+    );
+  };
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const [latestData, histData, healthData] = await Promise.all([
+          loadBenchmarkFile<BenchmarkData>('latest.json'),
+          loadBenchmarkFile<HistoricalData>('historical.json').catch(() => null),
+          loadBenchmarkFile<RunHealth>('run-health.json').catch(() => null)
+        ]);
+
+        setBenchmarkData(latestData);
+        if (histData) setHistoricalData(histData);
+        if (healthData) setRunHealth(healthData);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load data');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
+  }, []);
+
+  return (
+    <>
+      <div className="benchmark-page">
+        <div className="benchmark-page-container">
+          <a href="https://chrisaustin.dev" className="back-link">← chrisaustin.dev</a>
+
+          <header className="benchmark-header">
+            <h1>AI Egg Index</h1>
+            <p className="benchmark-tagline">
+              Benchmarking free tier LLMs on tasks regular people actually care about
+            </p>
+
+            <nav className="benchmark-nav">
+              <button
+                type="button"
+                className="benchmark-nav-toggle"
+                aria-haspopup="true"
+                aria-expanded={menuOpen}
+                onClick={() => setMenuOpen((o) => !o)}
+              >
+                {VIEW_LABELS[view]} <span className="nav-caret">▾</span>
+              </button>
+              {menuOpen && (
+                <ul className="benchmark-nav-menu" role="menu">
+                  {(Object.keys(VIEW_LABELS) as View[]).map((v) => (
+                    <li key={v} role="none">
+                      <button
+                        role="menuitem"
+                        className={v === view ? 'active' : ''}
+                        onClick={() => {
+                          setView(v);
+                          setMenuOpen(false);
+                        }}
+                      >
+                        {VIEW_LABELS[v]}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </nav>
+          </header>
+
+          {view === 'rankings' && (
+          <section className="benchmark-results">
+            <h2>Current Rankings</h2>
+            {loading ? (
+              <div className="loading-state">
+                <div className="loading-spinner"></div>
+                <p>Loading benchmark data...</p>
+              </div>
+            ) : error ? (
+              <div className="error-state">
+                <p>Error: {error}</p>
+                <p className="error-hint">Benchmark data may not be deployed yet.</p>
+              </div>
+            ) : benchmarkData ? (
+              <>
+                <p className="last-updated">
+                  Runs every week • Last updated: {benchmarkData.last_updated}
+                </p>
+                <p className="sample-caveat">
+                  Small-sample scores — read as a directional signal, not a precise ranking.
+                </p>
+                <BenchmarkComparer
+                  data={benchmarkData.models}
+                  historicalData={historicalData || undefined}
+                />
+              </>
+            ) : null}
+          </section>
+          )}
+
+          {view === 'about' && (
+          <>
+          <section className="benchmark-intro">
+            <div className="intro-content">
+              <h2>About the AI Egg Index</h2>
+              <p>
+                Why "Egg Index"? Most AI benchmarks are like complex economic models—abstract
+                scores that don't mean much to regular people. This aims to be more like the egg
+                price index: a simple, grounded measure of what actually matters. Can free AI help
+                with your taxes? Can it handle a complex reasoning task that someone might actually ask?
+              </p>
+            </div>
+          </section>
+
+          <section className="benchmark-intro">
+            <div className="intro-content">
+              <h2>Why This Matters</h2>
+              <p>
+                Academic benchmarks tell researchers how models perform on standardized tests.
+                But what about the rest of us? Can free AI actually help with taxes?
+                Will it follow complex instructions? Can it solve real math problems?
+              </p>
+              <p>
+                The AI Egg Index tracks free tier LLM performance over time on tasks
+                that matter to everyday users—like tracking egg prices tracks the economy.
+              </p>
+            </div>
+          </section>
+
+          <section className="benchmark-landscape">
+            <h2>How We're Different</h2>
+            <p className="landscape-intro">
+              Great AI benchmarks already exist, but they serve different purposes. Here's where we fit in:
+            </p>
+            <div className="comparison-table-wrapper">
+              <table className="comparison-table">
+                <thead>
+                  <tr>
+                    <th>Benchmark</th>
+                    <th>Focus</th>
+                    <th>Free Tier?</th>
+                    <th>Practical Tasks?</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <a href="https://huggingface.co/spaces/lmsys/chatbot-arena-leaderboard" target="_blank" rel="noopener noreferrer">
+                        LMSYS Chatbot Arena
+                      </a>
+                    </td>
+                    <td>Human preference voting</td>
+                    <td className="cell-no">All models</td>
+                    <td className="cell-partial">Vibes, not tasks</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a href="https://www.vals.ai/benchmarks/ace" target="_blank" rel="noopener noreferrer">
+                        ACE (AI Consumer Index)
+                      </a>
+                    </td>
+                    <td>Consumer activities</td>
+                    <td className="cell-no">Frontier models</td>
+                    <td className="cell-yes">Yes</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a href="https://scale.com/leaderboard" target="_blank" rel="noopener noreferrer">
+                        Scale Leaderboard
+                      </a>
+                    </td>
+                    <td>Enterprise tool use</td>
+                    <td className="cell-no">Enterprise</td>
+                    <td className="cell-no">Dev/Agent tasks</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <a href="https://github.com/openai/simple-evals" target="_blank" rel="noopener noreferrer">
+                        OpenAI Evals
+                      </a>
+                    </td>
+                    <td>Academic benchmarks</td>
+                    <td className="cell-no">All models</td>
+                    <td className="cell-no">Academic</td>
+                  </tr>
+                  <tr className="highlight-row">
+                    <td><strong>AI Egg Index</strong></td>
+                    <td>Everyday layperson tasks</td>
+                    <td className="cell-yes">Free only</td>
+                    <td className="cell-yes">Yes</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div className="differentiators">
+              <div className="diff-card">
+                <span className="diff-icon">🆓</span>
+                <h4>Free Tier Reality</h4>
+                <p>We test what you can actually use without paying—including rate limits and context constraints.</p>
+              </div>
+              <div className="diff-card">
+                <span className="diff-icon">✅</span>
+                <h4>Task Completion</h4>
+                <p>Not "which response feels better" but "can it actually answer my tax question correctly?"</p>
+              </div>
+              <div className="diff-card">
+                <span className="diff-icon">🔄</span>
+                <h4>Reproducible</h4>
+                <p>Versioned prompts, fixed test sets, public rubrics. Anyone can verify our results.</p>
+              </div>
+            </div>
+          </section>
+          </>
+          )}
+
+          {view === 'details' && (
+          <>
+          <section className="benchmark-categories">
+            <h2>The 4 Benchmarks</h2>
+            <div className="category-grid">
+              <div className="category-card custom">
+                <div className="category-badge">Custom</div>
+                <h3>Practical Knowledge</h3>
+                <p>
+                  Real-world info people actually search for: tax brackets, retirement limits,
+                  minimum wage, consumer rights. Tests if models have current, accurate knowledge.
+                </p>
+              </div>
+              <div className="category-card openbench">
+                <div className="category-badge">OpenBench</div>
+                <h3>IFEval</h3>
+                <p>
+                  Instruction following. When you say "format as a table" or "respond in exactly
+                  3 bullet points"—does the model actually do it?
+                </p>
+              </div>
+              <div className="category-card openbench">
+                <div className="category-badge">OpenBench</div>
+                <h3>GSM8K</h3>
+                <p>
+                  Grade school math word problems. If the model can't help your kid with homework,
+                  is it really that useful?
+                </p>
+              </div>
+              <div className="category-card custom">
+                <div className="category-badge">Custom</div>
+                <h3>Creative+Technical</h3>
+                <p>
+                  Push the limits: "Write a budget tracker that outputs summaries as haiku."
+                  Tests whether models can combine creativity with technical execution.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="benchmark-methodology">
+            <h2>Methodology</h2>
+            <div className="methodology-grid">
+              <div className="methodology-card">
+                <h3>Free Tier Only</h3>
+                <p>
+                  We only test models available for free. If you have to pay, it's not included.
+                  This keeps the index practical for regular users.
+                </p>
+              </div>
+              <div className="methodology-card">
+                <h3>LLM-as-Judge</h3>
+                <p>
+                  Custom benchmarks use LLM-as-judge scoring with rubrics for factual accuracy,
+                  completeness, and recency awareness. The judge is a stronger free-tier model
+                  (Llama 3.3 70B) — deliberately larger than the models under test, since the
+                  grader is infrastructure, not a contestant.
+                </p>
+              </div>
+              <div className="methodology-card">
+                <h3>Directional, Not Precise</h3>
+                <p>
+                  Each benchmark runs on a small sample per cycle, so scores are best read as a
+                  rough, directional signal — not a precise ranking. Expect some week-to-week
+                  movement to be sampling noise rather than real change.
+                </p>
+              </div>
+              <div className="methodology-card">
+                <h3>Historical Tracking</h3>
+                <p>
+                  We run the full benchmark suite once a week (automated every Sunday) and track
+                  changes over time. The sparklines in the table show recent runs — read them for
+                  broad direction, not exact deltas (see "Directional, Not Precise").
+                </p>
+              </div>
+              <div className="methodology-card">
+                <h3>Open Source</h3>
+                <p>
+                  All benchmark definitions, evaluation scripts, and results are open source.
+                  Check the repo to see exactly how we score.
+                </p>
+                <a
+                  href="https://github.com/Ceaustin117/ai-egg-index"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="github-repo-link"
+                >
+                  View on GitHub
+                </a>
+              </div>
+            </div>
+          </section>
+
+          <section className="benchmark-providers">
+            <h2>Free Tier Providers Tested</h2>
+            <div className="provider-list">
+              <div className="provider-item">
+                <span className="provider-name groq">Groq</span>
+                <span className="provider-limit">30 req/min</span>
+              </div>
+              <div className="provider-item">
+                <span className="provider-name google">Google</span>
+                <span className="provider-limit">10 req/min</span>
+              </div>
+              <div className="provider-item">
+                <span className="provider-name cohere">Cohere</span>
+                <span className="provider-limit">100 req/min</span>
+              </div>
+              <div className="provider-item">
+                <span className="provider-name huggingface">HuggingFace</span>
+                <span className="provider-limit">Rate limited</span>
+              </div>
+            </div>
+          </section>
+          </>
+          )}
+
+          {view === 'history' && (
+          <section className="benchmark-history">
+            <h2>History</h2>
+            <p className="history-intro">
+              How models have performed over time, and the health of each weekly run.
+            </p>
+            {historicalData && <PerformanceTrend data={historicalData} />}
+            {runHealth && <PipelineHealth data={runHealth} />}
+            {!historicalData && !runHealth && (
+              <p className="error-hint">History data is not available yet.</p>
+            )}
+          </section>
+          )}
+        </div>
+      </div>
+      <footer className="site-footer">
+        <p>
+          Open source ·{' '}
+          <a href="https://github.com/Ceaustin117/ai-egg-index">github.com/Ceaustin117/ai-egg-index</a>{' '}
+          · by <a href="https://chrisaustin.dev">Chris Austin</a>
+        </p>
+      </footer>
+    </>
+  );
+};
+
+export default BenchmarkPage;

--- a/site/src/components/BenchmarkComparer.css
+++ b/site/src/components/BenchmarkComparer.css
@@ -1,0 +1,382 @@
+.benchmark-comparer {
+  width: 100%;
+}
+
+.benchmark-controls {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-group label {
+  color: #a0aec0;
+  font-size: 0.9rem;
+}
+
+.filter-group select {
+  padding: 0.5rem 1rem;
+  background: rgba(26, 35, 50, 0.9);
+  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+.filter-group select:hover,
+.filter-group select:focus {
+  border-color: #06b6d4;
+  outline: none;
+}
+
+.benchmark-table-wrapper {
+  overflow-x: auto;
+  border-radius: 12px;
+  background: rgba(26, 35, 50, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.benchmark-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.benchmark-table th,
+.benchmark-table td {
+  padding: 1rem;
+  text-align: center;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.benchmark-table th {
+  background: rgba(10, 25, 41, 0.8);
+  color: #e2e8f0;
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.benchmark-table th.sortable {
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s ease;
+}
+
+.benchmark-table th.sortable:hover {
+  background: rgba(6, 182, 212, 0.2);
+}
+
+.benchmark-header {
+  min-width: 120px;
+}
+
+.benchmark-name {
+  display: block;
+  font-size: 0.85rem;
+}
+
+.benchmark-category {
+  display: block;
+  font-size: 0.7rem;
+  color: #718096;
+  font-weight: 400;
+  margin-top: 0.25rem;
+}
+
+.overall-header {
+  background: linear-gradient(135deg, rgba(6, 182, 212, 0.3), rgba(13, 148, 136, 0.3)) !important;
+}
+
+.benchmark-table tbody tr {
+  transition: background 0.2s ease;
+}
+
+.benchmark-table tbody tr:hover {
+  background: rgba(6, 182, 212, 0.1);
+}
+
+.model-name {
+  text-align: left;
+  font-weight: 600;
+  color: #ffffff;
+  min-width: 180px;
+}
+
+.model-text {
+  display: block;
+}
+
+.model-meta {
+  display: block;
+  font-size: 0.75rem;
+  color: #718096;
+  font-weight: 400;
+  margin-top: 0.25rem;
+}
+
+.provider-cell {
+  min-width: 100px;
+}
+
+.provider-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.provider-groq {
+  background: rgba(251, 191, 36, 0.2);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.3);
+}
+
+.provider-together {
+  background: rgba(167, 139, 250, 0.2);
+  color: #a78bfa;
+  border: 1px solid rgba(167, 139, 250, 0.3);
+}
+
+.provider-google {
+  background: rgba(52, 168, 83, 0.2);
+  color: #34a853;
+  border: 1px solid rgba(52, 168, 83, 0.3);
+}
+
+.provider-cohere {
+  background: rgba(236, 72, 153, 0.2);
+  color: #ec4899;
+  border: 1px solid rgba(236, 72, 153, 0.3);
+}
+
+.provider-huggingface {
+  background: rgba(255, 213, 0, 0.2);
+  color: #ffd500;
+  border: 1px solid rgba(255, 213, 0, 0.3);
+}
+
+.score-cell {
+  position: relative;
+}
+
+.score-cell.highlighted {
+  background: rgba(6, 182, 212, 0.15) !important;
+}
+
+.score-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.score-value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.overall-cell {
+  background: rgba(26, 35, 50, 0.4);
+}
+
+.overall-value {
+  font-size: 1.1rem;
+}
+
+.score-excellent .score-value {
+  color: #10b981;
+}
+
+.score-good .score-value {
+  color: #06b6d4;
+}
+
+.score-fair .score-value {
+  color: #fbbf24;
+}
+
+.score-poor .score-value {
+  color: #ef4444;
+}
+
+/* Benchmark attempted but the provider's free tier was unavailable this run */
+.score-unavailable .score-value,
+.score-na {
+  color: #64748b;
+  font-style: italic;
+}
+
+.score-cell.score-unavailable {
+  cursor: help;
+}
+
+/* Whole model row that produced no scores this run */
+.row-unavailable {
+  opacity: 0.55;
+}
+
+.unavailable-badge {
+  display: inline-block;
+  margin-top: 0.25rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 20px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: #94a3b8;
+  background: rgba(100, 116, 139, 0.18);
+}
+
+.trend-icon {
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
+.trend-up {
+  color: #10b981;
+}
+
+.trend-down {
+  color: #ef4444;
+}
+
+.trend-neutral {
+  color: #718096;
+}
+
+.sparkline {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.benchmark-tooltip {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(26, 35, 50, 0.95);
+  border: 1px solid rgba(6, 182, 212, 0.5);
+  border-radius: 8px;
+  padding: 1rem 1.5rem;
+  max-width: 300px;
+  text-align: center;
+  z-index: 100;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.benchmark-tooltip strong {
+  display: block;
+  color: #06b6d4;
+  margin-bottom: 0.5rem;
+}
+
+.benchmark-tooltip p {
+  color: #a0aec0;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.benchmark-legend {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #a0aec0;
+}
+
+.legend-color {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+}
+
+.legend-color.score-excellent {
+  background: #10b981;
+}
+
+.legend-color.score-good {
+  background: #06b6d4;
+}
+
+.legend-color.score-fair {
+  background: #fbbf24;
+}
+
+.legend-color.score-poor {
+  background: #ef4444;
+}
+
+@media (max-width: 1024px) {
+  .benchmark-table {
+    font-size: 0.85rem;
+  }
+
+  .benchmark-table th,
+  .benchmark-table td {
+    padding: 0.75rem 0.5rem;
+  }
+
+  .benchmark-header {
+    min-width: 100px;
+  }
+
+  .model-name {
+    min-width: 140px;
+  }
+}
+
+@media (max-width: 768px) {
+  .benchmark-controls {
+    justify-content: center;
+  }
+
+  .benchmark-table {
+    font-size: 0.8rem;
+  }
+
+  .benchmark-name {
+    font-size: 0.75rem;
+  }
+
+  .benchmark-category {
+    display: none;
+  }
+
+  .score-value {
+    font-size: 0.9rem;
+  }
+
+  .sparkline {
+    display: none;
+  }
+
+  .benchmark-legend {
+    gap: 1rem;
+  }
+
+  .legend-item {
+    font-size: 0.8rem;
+  }
+}

--- a/site/src/components/BenchmarkComparer.tsx
+++ b/site/src/components/BenchmarkComparer.tsx
@@ -1,0 +1,304 @@
+import React, { useState, useMemo } from 'react';
+import { BenchmarkResult, HistoricalData } from '../types';
+import './BenchmarkComparer.css';
+
+interface BenchmarkComparerProps {
+  data: BenchmarkResult[];
+  historicalData?: HistoricalData;
+}
+
+type SortField = 'model' | 'provider' | 'practical_knowledge' | 'ifeval' | 'gsm8k' | 'creative_technical' | 'overall';
+type SortDirection = 'asc' | 'desc';
+
+const BENCHMARK_INFO: Record<string, { name: string; description: string; category: string }> = {
+  practical_knowledge: {
+    name: 'Practical Knowledge',
+    description: 'Real-world info: taxes, regulations, finance',
+    category: 'Custom'
+  },
+  ifeval: {
+    name: 'IFEval',
+    description: 'Following complex instructions',
+    category: 'OpenBench'
+  },
+  gsm8k: {
+    name: 'GSM8K',
+    description: 'Math word problems',
+    category: 'OpenBench'
+  },
+  creative_technical: {
+    name: 'Creative+Technical',
+    description: 'Coding with creative constraints',
+    category: 'Custom'
+  }
+};
+
+const BENCHMARK_KEYS = ['practical_knowledge', 'ifeval', 'gsm8k', 'creative_technical'] as const;
+
+const BenchmarkComparer: React.FC<BenchmarkComparerProps> = ({ data, historicalData }) => {
+  const [sortField, setSortField] = useState<SortField>('overall');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [selectedBenchmark, setSelectedBenchmark] = useState<string | null>(null);
+  const [providerFilter, setProviderFilter] = useState<string>('all');
+
+  const providers = useMemo(() => {
+    const uniqueProviders = Array.from(new Set(data.map(d => d.provider)));
+    return ['all', ...uniqueProviders.sort()];
+  }, [data]);
+
+  const calculateOverall = (model: BenchmarkResult): number => {
+    const scores = BENCHMARK_KEYS.map(key => model.benchmarks[key]?.score ?? 0);
+    const validScores = scores.filter(s => s > 0);
+    return validScores.length > 0 ? validScores.reduce((a, b) => a + b, 0) / validScores.length : 0;
+  };
+
+  const getScoreClass = (score: number): string => {
+    if (score >= 0.75) return 'score-excellent';
+    if (score >= 0.6) return 'score-good';
+    if (score >= 0.4) return 'score-fair';
+    return 'score-poor';
+  };
+
+  const formatScore = (score: number | null | undefined): string => {
+    if (score === undefined || score === null || score === 0) return '—';
+    return (score * 100).toFixed(0) + '%';
+  };
+
+  // A benchmark that was attempted but failed (provider unavailable) has score === null
+  // with status 'error'. Distinct from a benchmark that simply wasn't run (undefined).
+  const isBenchError = (bench?: BenchmarkResult['benchmarks'][keyof BenchmarkResult['benchmarks']]): boolean =>
+    !!bench && (bench.status === 'error' || bench.score === null);
+
+  // A whole row is "unavailable" when every benchmark either failed or was never run.
+  const isModelUnavailable = (model: BenchmarkResult): boolean =>
+    BENCHMARK_KEYS.every(key => {
+      const bench = model.benchmarks[key];
+      return !bench || isBenchError(bench);
+    });
+
+  const getTrend = (model: string, benchmark: string): 'up' | 'down' | 'neutral' | null => {
+    if (!historicalData?.models[model]) return null;
+    // Prefer the smoothed rolling series (noise-resistant); fall back to raw scores.
+    const scores = historicalData.models[model].rolling ?? historicalData.models[model].scores;
+    if (scores.length < 2) return null;
+
+    const latest = scores[scores.length - 1][benchmark as keyof typeof scores[0]] as number | undefined;
+    const previous = scores[scores.length - 2][benchmark as keyof typeof scores[0]] as number | undefined;
+
+    if (latest === undefined || previous === undefined) return null;
+    if (latest > previous + 0.02) return 'up';
+    if (latest < previous - 0.02) return 'down';
+    return 'neutral';
+  };
+
+  const renderTrendIcon = (trend: 'up' | 'down' | 'neutral' | null) => {
+    if (!trend) return null;
+    if (trend === 'up') return <span className="trend-icon trend-up">↑</span>;
+    if (trend === 'down') return <span className="trend-icon trend-down">↓</span>;
+    return <span className="trend-icon trend-neutral">→</span>;
+  };
+
+  const sortedData = useMemo(() => {
+    let filtered = providerFilter === 'all' ? data : data.filter(d => d.provider === providerFilter);
+
+    return [...filtered].sort((a, b) => {
+      let aVal: number | string;
+      let bVal: number | string;
+
+      if (sortField === 'model' || sortField === 'provider') {
+        aVal = a[sortField].toLowerCase();
+        bVal = b[sortField].toLowerCase();
+      } else if (sortField === 'overall') {
+        aVal = calculateOverall(a);
+        bVal = calculateOverall(b);
+      } else {
+        aVal = a.benchmarks[sortField]?.score ?? 0;
+        bVal = b.benchmarks[sortField]?.score ?? 0;
+      }
+
+      if (typeof aVal === 'string' && typeof bVal === 'string') {
+        return sortDirection === 'asc' ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+      }
+      return sortDirection === 'asc' ? (aVal as number) - (bVal as number) : (bVal as number) - (aVal as number);
+    });
+  }, [data, sortField, sortDirection, providerFilter]);
+
+  const handleSort = (field: SortField) => {
+    if (field === sortField) {
+      setSortDirection(d => d === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection('desc');
+    }
+  };
+
+  const renderSortIndicator = (field: SortField) => {
+    if (sortField !== field) return null;
+    return sortDirection === 'asc' ? ' ↑' : ' ↓';
+  };
+
+  const renderSparkline = (model: string, benchmark: string) => {
+    if (!historicalData?.models[model]) return null;
+    // Prefer the smoothed rolling series (noise-resistant); fall back to raw scores.
+    const scores = historicalData.models[model].rolling ?? historicalData.models[model].scores;
+    if (scores.length < 2) return null;
+
+    const values = scores.map(s => (s[benchmark as keyof typeof s] as number) ?? 0).filter(v => v > 0);
+    if (values.length < 2) return null;
+
+    const max = Math.max(...values);
+    const min = Math.min(...values);
+    const range = max - min || 1;
+    const width = 60;
+    const height = 20;
+    const padding = 2;
+
+    const points = values.map((v, i) => {
+      const x = padding + (i / (values.length - 1)) * (width - 2 * padding);
+      const y = height - padding - ((v - min) / range) * (height - 2 * padding);
+      return `${x},${y}`;
+    }).join(' ');
+
+    return (
+      <svg className="sparkline" width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        <polyline
+          fill="none"
+          stroke="#06b6d4"
+          strokeWidth="1.5"
+          points={points}
+        />
+      </svg>
+    );
+  };
+
+  return (
+    <div className="benchmark-comparer">
+      <div className="benchmark-controls">
+        <div className="filter-group">
+          <label htmlFor="provider-filter">Provider:</label>
+          <select
+            id="provider-filter"
+            value={providerFilter}
+            onChange={(e) => setProviderFilter(e.target.value)}
+          >
+            {providers.map(p => (
+              <option key={p} value={p}>
+                {p === 'all' ? 'All Providers' : p.charAt(0).toUpperCase() + p.slice(1)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="benchmark-table-wrapper">
+        <table className="benchmark-table">
+          <thead>
+            <tr>
+              <th onClick={() => handleSort('model')} className="sortable">
+                Model{renderSortIndicator('model')}
+              </th>
+              <th onClick={() => handleSort('provider')} className="sortable">
+                Provider{renderSortIndicator('provider')}
+              </th>
+              {BENCHMARK_KEYS.map(key => (
+                <th
+                  key={key}
+                  onClick={() => handleSort(key as SortField)}
+                  onMouseEnter={() => setSelectedBenchmark(key)}
+                  onMouseLeave={() => setSelectedBenchmark(null)}
+                  className="sortable benchmark-header"
+                  title={BENCHMARK_INFO[key].description}
+                >
+                  <span className="benchmark-name">{BENCHMARK_INFO[key].name}</span>
+                  <span className="benchmark-category">{BENCHMARK_INFO[key].category}</span>
+                  {renderSortIndicator(key as SortField)}
+                </th>
+              ))}
+              <th onClick={() => handleSort('overall')} className="sortable overall-header">
+                Overall{renderSortIndicator('overall')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedData.map((model) => {
+              const overall = calculateOverall(model);
+              const unavailable = isModelUnavailable(model);
+              return (
+                <tr key={model.model} className={unavailable ? 'row-unavailable' : ''}>
+                  <td className="model-name">
+                    <span className="model-text">{model.model.split('/').pop()}</span>
+                    {model.metadata?.context_window && (
+                      <span className="model-meta">{(model.metadata.context_window / 1000).toFixed(0)}K ctx</span>
+                    )}
+                    {unavailable && <span className="unavailable-badge">unavailable</span>}
+                  </td>
+                  <td className="provider-cell">
+                    <span className={`provider-badge provider-${model.provider}`}>
+                      {model.provider}
+                    </span>
+                  </td>
+                  {BENCHMARK_KEYS.map(key => {
+                    const bench = model.benchmarks[key];
+                    const score = bench?.score;
+                    const errored = isBenchError(bench);
+                    const trend = getTrend(model.model, key);
+                    return (
+                      <td
+                        key={key}
+                        className={`score-cell ${errored ? 'score-unavailable' : (score ? getScoreClass(score) : '')} ${selectedBenchmark === key ? 'highlighted' : ''}`}
+                        title={errored ? `Unavailable this run: ${bench?.error ?? 'provider error'}` : undefined}
+                      >
+                        <div className="score-content">
+                          {errored ? (
+                            <span className="score-value score-na">N/A</span>
+                          ) : (
+                            <>
+                              <span className="score-value">{formatScore(score)}</span>
+                              {renderTrendIcon(trend)}
+                              {renderSparkline(model.model, key)}
+                            </>
+                          )}
+                        </div>
+                      </td>
+                    );
+                  })}
+                  <td className={`score-cell overall-cell ${unavailable ? 'score-unavailable' : getScoreClass(overall)}`}>
+                    <span className="score-value overall-value">{unavailable ? 'N/A' : formatScore(overall)}</span>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {selectedBenchmark && (
+        <div className="benchmark-tooltip">
+          <strong>{BENCHMARK_INFO[selectedBenchmark].name}</strong>
+          <p>{BENCHMARK_INFO[selectedBenchmark].description}</p>
+        </div>
+      )}
+
+      <div className="benchmark-legend">
+        <div className="legend-item">
+          <span className="legend-color score-excellent"></span>
+          <span>Excellent (75%+)</span>
+        </div>
+        <div className="legend-item">
+          <span className="legend-color score-good"></span>
+          <span>Good (60-74%)</span>
+        </div>
+        <div className="legend-item">
+          <span className="legend-color score-fair"></span>
+          <span>Fair (40-59%)</span>
+        </div>
+        <div className="legend-item">
+          <span className="legend-color score-poor"></span>
+          <span>Poor (&lt;40%)</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BenchmarkComparer;

--- a/site/src/components/PerformanceTrend.css
+++ b/site/src/components/PerformanceTrend.css
@@ -1,0 +1,48 @@
+.performance-trend {
+  margin: 2rem 0;
+}
+
+.performance-trend h2 {
+  margin-bottom: 0.5rem;
+}
+
+.pt-sub {
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.9rem;
+  margin-bottom: 1rem;
+  max-width: 60ch;
+}
+
+.pt-chart-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.pt-chart {
+  width: 100%;
+  min-width: 480px;
+  height: auto;
+  display: block;
+}
+
+.pt-grid {
+  stroke: rgba(148, 163, 184, 0.18);
+  stroke-width: 1;
+}
+
+.pt-axis {
+  fill: var(--text-muted, #94a3b8);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.pt-line {
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.pt-legend {
+  fill: var(--text-primary, #e2e8f0);
+  font-size: 12px;
+  dominant-baseline: middle;
+}

--- a/site/src/components/PerformanceTrend.tsx
+++ b/site/src/components/PerformanceTrend.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { HistoricalData, HistoricalScoreEntry } from '../types';
+import './PerformanceTrend.css';
+
+interface PerformanceTrendProps {
+  data: HistoricalData;
+}
+
+const BENCH_KEYS: (keyof HistoricalScoreEntry)[] = [
+  'practical_knowledge',
+  'ifeval',
+  'gsm8k',
+  'creative_technical',
+];
+
+const LINE_COLORS = ['#06b6d4', '#fbbf24', '#a78bfa', '#34d399', '#f87171', '#f472b6'];
+
+const shortModel = (m: string) => m.split('/').pop() || m;
+
+/** Overall (composite) score for one historical entry: mean of the benchmarks present. */
+function overallOf(entry: HistoricalScoreEntry): number | null {
+  const vals = BENCH_KEYS.map((k) => entry[k]).filter((v): v is number => typeof v === 'number');
+  if (!vals.length) return null;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+
+/**
+ * Multi-line chart of each model's overall score over time, using the smoothed `rolling`
+ * series when available. Answers "which models are performing better over time" at a glance.
+ */
+const PerformanceTrend: React.FC<PerformanceTrendProps> = ({ data }) => {
+  const models = Object.entries(data.models);
+  if (!models.length) return null;
+
+  // Build each model's overall-over-time series (smoothed series preferred).
+  const series = models.map(([name, m], i) => {
+    const entries = m.rolling ?? m.scores;
+    const points = entries
+      .map((e) => ({ date: e.date, value: overallOf(e) }))
+      .filter((p): p is { date: string; value: number } => p.value !== null);
+    return { name, color: LINE_COLORS[i % LINE_COLORS.length], points };
+  }).filter((s) => s.points.length > 0);
+
+  if (!series.length) return null;
+
+  // Shared x-axis: sorted union of all dates across models.
+  const dates = Array.from(new Set(series.flatMap((s) => s.points.map((p) => p.date)))).sort();
+  if (dates.length < 2) return null;
+  const xIndex = new Map(dates.map((d, i) => [d, i]));
+
+  const W = 720;
+  const H = 340;
+  const pad = { top: 20, right: 150, bottom: 36, left: 38 };
+  const plotW = W - pad.left - pad.right;
+  const plotH = H - pad.top - pad.bottom;
+
+  const x = (date: string) => pad.left + (xIndex.get(date)! / (dates.length - 1)) * plotW;
+  const y = (v: number) => pad.top + (1 - v) * plotH;
+
+  const yTicks = [0, 0.25, 0.5, 0.75, 1];
+  // Label a handful of x dates to avoid crowding.
+  const xLabelIdx = [0, Math.floor((dates.length - 1) / 2), dates.length - 1];
+
+  return (
+    <section className="performance-trend">
+      <h2>Performance Over Time</h2>
+      <p className="pt-sub">
+        Each model's overall score (composite of its benchmarks), smoothed across weekly
+        runs. Lines crossing = the lead changed hands.
+      </p>
+
+      <div className="pt-chart-wrap">
+        <svg className="pt-chart" viewBox={`0 0 ${W} ${H}`} role="img" aria-label="Model performance over time">
+          {/* gridlines + y labels */}
+          {yTicks.map((t) => (
+            <g key={t}>
+              <line x1={pad.left} y1={y(t)} x2={pad.left + plotW} y2={y(t)} className="pt-grid" />
+              <text x={pad.left - 6} y={y(t) + 3} className="pt-axis" textAnchor="end">
+                {t.toFixed(2)}
+              </text>
+            </g>
+          ))}
+
+          {/* x date labels */}
+          {xLabelIdx.map((i) => (
+            <text key={i} x={x(dates[i])} y={H - 12} className="pt-axis" textAnchor="middle">
+              {dates[i].slice(5)}
+            </text>
+          ))}
+
+          {/* one polyline per model + endpoint dots */}
+          {series.map((s) => {
+            const pts = s.points.map((p) => `${x(p.date)},${y(p.value)}`).join(' ');
+            const last = s.points[s.points.length - 1];
+            return (
+              <g key={s.name}>
+                <polyline points={pts} fill="none" stroke={s.color} strokeWidth={2} className="pt-line" />
+                <circle cx={x(last.date)} cy={y(last.value)} r={3} fill={s.color} />
+              </g>
+            );
+          })}
+
+          {/* legend */}
+          {series.map((s, i) => (
+            <g key={s.name} transform={`translate(${pad.left + plotW + 14}, ${pad.top + 6 + i * 20})`}>
+              <rect width={10} height={10} y={-9} fill={s.color} rx={2} />
+              <text x={16} className="pt-legend">{shortModel(s.name)}</text>
+            </g>
+          ))}
+        </svg>
+      </div>
+    </section>
+  );
+};
+
+export default PerformanceTrend;

--- a/site/src/components/PipelineHealth.css
+++ b/site/src/components/PipelineHealth.css
@@ -1,0 +1,61 @@
+.pipeline-health {
+  margin: 2rem 0;
+}
+
+.pipeline-health h2 {
+  margin-bottom: 0.5rem;
+}
+
+.ph-sub {
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.9rem;
+  margin-bottom: 1.25rem;
+  max-width: 60ch;
+}
+
+.ph-timeline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.ph-run {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 3rem;
+}
+
+.ph-dot {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.ph-run.ok .ph-dot {
+  background: #22c55e;
+  box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
+}
+
+.ph-run.warn .ph-dot {
+  background: var(--button-primary, #fbbf24);
+  box-shadow: 0 0 6px rgba(251, 191, 36, 0.5);
+}
+
+.ph-date {
+  font-size: 0.72rem;
+  color: var(--text-muted, #94a3b8);
+  font-variant-numeric: tabular-nums;
+}
+
+.ph-latest {
+  font-size: 0.9rem;
+  color: var(--text-muted, #94a3b8);
+}
+
+.ph-issues {
+  color: var(--button-primary, #fbbf24);
+}

--- a/site/src/components/PipelineHealth.tsx
+++ b/site/src/components/PipelineHealth.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { RunHealth } from '../types';
+import './PipelineHealth.css';
+
+interface PipelineHealthProps {
+  data: RunHealth;
+}
+
+const shortModel = (m: string) => m.split('/').pop() || m;
+
+/**
+ * Compact run-over-run pipeline health from output/run-health.json:
+ * a timeline of recent weekly runs (green = all benchmarks scored, amber = one or
+ * more errored — usually a provider's free-tier quota), plus the latest run's issues.
+ */
+const PipelineHealth: React.FC<PipelineHealthProps> = ({ data }) => {
+  const runs = data.runs.slice(-12);
+  if (runs.length === 0) return null;
+
+  const latest = runs[runs.length - 1];
+  const issuesByModel: Record<string, string[]> = {};
+  Object.entries(latest.cells).forEach(([model, cells]) => {
+    const errored = Object.entries(cells)
+      .filter(([, status]) => status === 'error')
+      .map(([bench]) => bench);
+    if (errored.length) issuesByModel[model] = errored;
+  });
+
+  return (
+    <section className="pipeline-health">
+      <h2>Pipeline Health</h2>
+      <p className="ph-sub">
+        Each weekly run. Green = every benchmark scored; amber = one or more errored
+        (usually a provider's free-tier quota, handled gracefully — not a fake zero).
+      </p>
+
+      <div className="ph-timeline">
+        {runs.map((run) => {
+          const healthy = run.summary.error === 0;
+          return (
+            <div
+              key={run.date}
+              className={`ph-run ${healthy ? 'ok' : 'warn'}`}
+              title={`${run.date}: ${run.summary.ok}/${run.summary.total} benchmark runs healthy`}
+            >
+              <span className="ph-dot" aria-hidden="true" />
+              <span className="ph-date">{run.date.slice(5)}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className="ph-latest">
+        Latest run <strong>{latest.date}</strong>: {latest.summary.ok}/{latest.summary.total}{' '}
+        benchmark runs healthy
+        {Object.keys(issuesByModel).length > 0 && (
+          <>
+            {' — '}
+            <span className="ph-issues">
+              {Object.entries(issuesByModel)
+                .map(([model, benches]) => `${shortModel(model)} (${benches.join(', ')})`)
+                .join('; ')}
+            </span>
+          </>
+        )}
+      </p>
+    </section>
+  );
+};
+
+export default PipelineHealth;

--- a/site/src/index.css
+++ b/site/src/index.css
@@ -1,0 +1,41 @@
+:root {
+  --primary-bg: #0a1929;
+  --secondary-bg: #1a2332;
+  --accent-bg: #2d3748;
+  --text-primary: #ffffff;
+  --text-secondary: #e2e8f0;
+  --text-muted: #a0aec0;
+  --accent-yellow: #fbbf24;
+  --accent-cyan: #06b6d4;
+  --accent-teal: #0d9488;
+  --button-primary: #fbbf24;
+  --button-hover: #f59e0b;
+  --card-bg: rgba(26, 35, 50, 0.8);
+  --border-color: rgba(148, 163, 184, 0.2);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--primary-bg);
+  color: var(--text-secondary);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--accent-cyan);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}

--- a/site/src/loadBenchmarkData.ts
+++ b/site/src/loadBenchmarkData.ts
@@ -1,0 +1,12 @@
+// The project site bundles its own benchmark data (copied from the repo's output/ at
+// build time into public/data/), so it loads from its own origin — no dependency on
+// raw.githubusercontent.com. import.meta.env.BASE_URL is "/ai-egg-index/" in production.
+type BenchmarkFile = 'latest.json' | 'historical.json' | 'run-health.json';
+
+export async function loadBenchmarkFile<T>(file: BenchmarkFile): Promise<T> {
+  const res = await fetch(`${import.meta.env.BASE_URL}data/${file}`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error(`Failed to load ${file} (HTTP ${res.status})`);
+  }
+  return (await res.json()) as T;
+}

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import BenchmarkPage from './BenchmarkPage';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BenchmarkPage />
+  </React.StrictMode>,
+);

--- a/site/src/types.ts
+++ b/site/src/types.ts
@@ -1,0 +1,137 @@
+export interface Project {
+  id: string;
+  title: string;
+  description: string;
+  technologies: string[];
+  imageUrl?: string;
+  liveUrl?: string;
+  githubUrl?: string;
+  featured: boolean;
+}
+
+export interface Skill {
+  name: string;
+  category: 'ai' | 'ml' | 'cloud' | 'tools' | 'all';
+  proficiency: 'beginner' | 'intermediate' | 'advanced' | 'expert';
+}
+
+export interface Experience {
+  id: string;
+  company: string;
+  position: string;
+  startDate: string;
+  endDate?: string;
+  description: string;
+  technologies: string[];
+}
+
+export interface ContactInfo {
+  email: string;
+  linkedin?: string;
+  github?: string;
+  twitter?: string;
+  phone?: string;
+}
+
+export interface PersonalInfo {
+  name: string;
+  title: string;
+  summary: string;
+  location: string;
+  contact: ContactInfo;
+}
+
+export interface NavSubItem {
+  id: string;
+  label: string;
+}
+
+export interface NavItem {
+  id: string;
+  label: string;
+  href: string;
+  // When present, this nav item renders as a dropdown instead of a plain link.
+  subItems?: NavSubItem[];
+}
+
+// Benchmark types for the Practical AI Index
+export interface BenchmarkScoreDetails {
+  [key: string]: number;
+}
+
+export interface BenchmarkScore {
+  // null when the benchmark could not be run (e.g. the provider's free tier was
+  // unavailable that run). Distinguishes "we tried and the API failed" from a real low score.
+  score: number | null;
+  status?: 'ok' | 'error';
+  error?: string;
+  details?: BenchmarkScoreDetails;
+  pass_at_1?: number;
+  strict?: number;
+  loose?: number;
+  accuracy?: number;
+}
+
+export interface BenchmarkResult {
+  model: string;
+  provider: string;
+  tier: 'free' | 'paid';
+  date: string;
+  benchmarks: {
+    practical_knowledge?: BenchmarkScore;
+    ifeval?: BenchmarkScore;
+    gsm8k?: BenchmarkScore;
+    creative_technical?: BenchmarkScore;
+  };
+  metadata?: {
+    knowledge_cutoff?: string;
+    context_window?: number;
+    rate_limit?: string;
+  };
+}
+
+export interface BenchmarkData {
+  last_updated: string;
+  models: BenchmarkResult[];
+}
+
+export interface HistoricalScoreEntry {
+  date: string;
+  practical_knowledge?: number;
+  ifeval?: number;
+  gsm8k?: number;
+  creative_technical?: number;
+}
+
+export interface HistoricalModelData {
+  provider: string;
+  tier: string;
+  scores: HistoricalScoreEntry[];
+  // Trailing-window smoothed series (same shape as scores). Present when the
+  // aggregator emits it; prefer it over raw `scores` for noise-resistant trends.
+  rolling?: HistoricalScoreEntry[];
+}
+
+export interface HistoricalData {
+  last_updated: string;
+  models: {
+    [modelName: string]: HistoricalModelData;
+  };
+}
+
+// Run-health tracking (output/run-health.json) — per-run pipeline health.
+export type CellStatus = 'ok' | 'error';
+
+export interface RunHealthEntry {
+  date: string;
+  models: string[];
+  cells: {
+    [modelName: string]: { [benchmark: string]: CellStatus };
+  };
+  summary: { ok: number; error: number; total: number };
+}
+
+export interface RunHealth {
+  last_updated: string;
+  runs: RunHealthEntry[];
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src"]
+}

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Project GitHub Pages site is served from https://ceaustin117.github.io/ai-egg-index/,
+// so the base path must match the repo name.
+export default defineConfig({
+  plugins: [react()],
+  base: '/ai-egg-index/',
+});


### PR DESCRIPTION
Gives the AI Egg Index its own home at **ceaustin117.github.io/ai-egg-index**, independent of the personal portfolio.

- `site/` — Vite + React + TS port of the leaderboard (comparer, performance-over-time chart, pipeline health, tabbed Rankings/About/Details/History). react-router removed; deep-linkable tabs kept via History API.
- Loads its **own** data: prebuild copies `output/*.json` into the site; app fetches from its own origin (no raw.githubusercontent dependency).
- `deploy-site.yml` — Actions build+deploy to Pages on pushes to main touching `site/` or `output/`, so the weekly benchmark run auto-refreshes the site.

Built locally successfully. After merge, Pages source must be set to 'GitHub Actions' (doing that next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)