### PR TITLE
Project site: horizontal tab bar instead of nav dropdown

### DIFF
--- a/site/src/BenchmarkPage.css
+++ b/site/src/BenchmarkPage.css
@@ -536,3 +536,35 @@
     font-size: 1.5rem;
   }
 }
+
+/* Horizontal tab bar under the header description (replaces the dropdown) */
+.benchmark-tabs {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 1.5rem;
+  border-bottom: 1px solid var(--border-color, rgba(148, 163, 184, 0.2));
+}
+
+.benchmark-tab {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted, #a0aec0);
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.6rem 1.15rem;
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.benchmark-tab:hover {
+  color: var(--text-primary, #ffffff);
+}
+
+.benchmark-tab.active {
+  color: var(--accent-cyan, #06b6d4);
+  border-bottom-color: var(--accent-cyan, #06b6d4);
+}

--- a/site/src/BenchmarkPage.tsx
+++ b/site/src/BenchmarkPage.tsx
@@ -21,7 +21,6 @@ const BenchmarkPage: React.FC = () => {
   const [runHealth, setRunHealth] = useState<RunHealth | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [menuOpen, setMenuOpen] = useState(false);
 
   // The active view is driven by the `?view=` query param so it can be deep-linked
   // (e.g. from the header dropdown). Falls back to 'rankings' when absent/invalid.
@@ -79,34 +78,19 @@ const BenchmarkPage: React.FC = () => {
               Benchmarking free tier LLMs on tasks regular people actually care about
             </p>
 
-            <nav className="benchmark-nav">
-              <button
-                type="button"
-                className="benchmark-nav-toggle"
-                aria-haspopup="true"
-                aria-expanded={menuOpen}
-                onClick={() => setMenuOpen((o) => !o)}
-              >
-                {VIEW_LABELS[view]} <span className="nav-caret">▾</span>
-              </button>
-              {menuOpen && (
-                <ul className="benchmark-nav-menu" role="menu">
-                  {(Object.keys(VIEW_LABELS) as View[]).map((v) => (
-                    <li key={v} role="none">
-                      <button
-                        role="menuitem"
-                        className={v === view ? 'active' : ''}
-                        onClick={() => {
-                          setView(v);
-                          setMenuOpen(false);
-                        }}
-                      >
-                        {VIEW_LABELS[v]}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              )}
+            <nav className="benchmark-tabs" role="tablist">
+              {(Object.keys(VIEW_LABELS) as View[]).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  role="tab"
+                  aria-selected={v === view}
+                  className={`benchmark-tab ${v === view ? 'active' : ''}`}
+                  onClick={() => setView(v)}
+                >
+                  {VIEW_LABELS[v]}
+                </button>
+              ))}
             </nav>
           </header>
 


### PR DESCRIPTION
Under the header description, the four views (Rankings / About / Details / History) now show as a centered horizontal tab bar with the active one highlighted, instead of a dropdown. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)