### PR TITLE
Make the project site crawlable / citable (GEO)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,11 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AI Egg Index — free-tier LLM benchmark</title>
+    <title>AI Egg Index — the everyday index for AI</title>
     <meta
       name="description"
-      content="Benchmarking free-tier LLMs on tasks regular people actually care about — updated weekly. Open source."
+      content="An open-source benchmark of free-tier LLMs on everyday tasks (practical knowledge, instruction following, math, coding), updated weekly."
     />
+    <link rel="canonical" href="https://ceaustin117.github.io/ai-egg-index/" />
+    <!-- Open Graph / social + link previews -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="AI Egg Index — the everyday index for AI" />
+    <meta
+      property="og:description"
+      content="Which free AI is actually good at everyday tasks? An open, weekly benchmark of free-tier LLMs."
+    />
+    <meta property="og:url" content="https://ceaustin117.github.io/ai-egg-index/" />
+    <meta property="og:image" content="https://ceaustin117.github.io/ai-egg-index/og.png" />
+    <meta name="twitter:card" content="summary_large_image" />
   </head>
   <body>
     <div id="root"></div>

--- a/site/package.json
+++ b/site/package.json
@@ -7,7 +7,7 @@
     "predev": "node scripts/copy-data.mjs",
     "dev": "vite",
     "prebuild": "node scripts/copy-data.mjs",
-    "build": "vite build",
+    "build": "vite build && node scripts/inject-static.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,5 @@
+# The AI Egg Index is open — allow all crawlers, including AI answer engines.
+User-agent: *
+Allow: /
+
+Sitemap: https://ceaustin117.github.io/ai-egg-index/sitemap.xml

--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ceaustin117.github.io/ai-egg-index/</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+</urlset>

--- a/site/scripts/inject-static.mjs
+++ b/site/scripts/inject-static.mjs
@@ -1,0 +1,83 @@
+// Post-build: inject a static, crawlable fallback + Dataset JSON-LD into dist/index.html.
+// The app is a client-rendered SPA, so without this, AI crawlers (Perplexity/ChatGPT) and
+// non-JS bots see an empty page. We render the current rankings as real HTML inside #root
+// (React replaces it on mount for JS users) plus a dated quotable sentence + structured
+// data — exactly what answer engines cite. Runs after `vite build` (see package.json).
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dist = join(here, '..', 'dist');
+const indexPath = join(dist, 'index.html');
+const dataPath = join(dist, 'data', 'latest.json');
+
+if (!existsSync(dataPath)) {
+  console.warn('[inject-static] no dist/data/latest.json; skipping');
+  process.exit(0);
+}
+
+const data = JSON.parse(readFileSync(dataPath, 'utf8'));
+const BENCH = [
+  ['practical_knowledge', 'Practical'],
+  ['ifeval', 'IFEval'],
+  ['gsm8k', 'GSM8K'],
+  ['creative_technical', 'Creative'],
+];
+const esc = (s) =>
+  String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+const overall = (b) => {
+  const v = Object.values(b || {}).filter((x) => x && typeof x.score === 'number').map((x) => x.score);
+  return v.length ? v.reduce((a, c) => a + c, 0) / v.length : 0;
+};
+const cell = (x) => (x == null ? '—' : x.status === 'error' || x.score == null ? 'N/A' : Math.round(x.score * 100) + '%');
+
+const models = [...data.models].sort((a, b) => overall(b.benchmarks) - overall(a.benchmarks));
+const top = models[0];
+const rows = models
+  .map((m) => {
+    const b = m.benchmarks || {};
+    const tds = BENCH.map(([k]) => `<td>${cell(b[k])}</td>`).join('');
+    return `<tr><td>${esc(m.model.split('/').pop())}</td><td>${esc(m.provider || '')}</td>${tds}<td><strong>${Math.round(overall(b) * 100)}%</strong></td></tr>`;
+  })
+  .join('');
+
+const sentence = `As of ${esc(data.last_updated)}, the AI Egg Index ranks free-tier LLMs on everyday tasks. The current top free model overall is ${esc(top.model.split('/').pop())} (${esc(top.provider)}) at ${Math.round(overall(top.benchmarks) * 100)}%. Scores are small-sample and directional.`;
+
+const staticHtml = `
+      <main>
+        <h1>AI Egg Index — the everyday index for AI</h1>
+        <p>${sentence}</p>
+        <table>
+          <thead><tr><th>Model</th><th>Provider</th><th>Practical</th><th>IFEval</th><th>GSM8K</th><th>Creative</th><th>Overall</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+        <p>Free-tier only, everyday tasks, updated weekly. Open source:
+          <a href="https://github.com/Ceaustin117/ai-egg-index">github.com/Ceaustin117/ai-egg-index</a></p>
+      </main>`;
+
+const jsonld = {
+  '@context': 'https://schema.org',
+  '@type': 'Dataset',
+  name: 'AI Egg Index',
+  description:
+    'Weekly benchmark of free-tier LLMs on everyday tasks (practical knowledge, instruction following, math, coding).',
+  url: 'https://ceaustin117.github.io/ai-egg-index/',
+  license: 'https://creativecommons.org/licenses/by/4.0/',
+  creator: { '@type': 'Person', name: 'Chris Austin', url: 'https://chrisaustin.dev' },
+  dateModified: data.last_updated,
+  isAccessibleForFree: true,
+  distribution: [
+    {
+      '@type': 'DataDownload',
+      encodingFormat: 'application/json',
+      contentUrl: 'https://ceaustin117.github.io/ai-egg-index/data/latest.json',
+    },
+  ],
+};
+
+let html = readFileSync(indexPath, 'utf8');
+html = html.replace('</head>', `    <script type="application/ld+json">${JSON.stringify(jsonld)}</script>\n  </head>`);
+html = html.replace('<div id="root"></div>', `<div id="root">${staticHtml}\n    </div>`);
+writeFileSync(indexPath, html);
+console.log('[inject-static] injected static fallback table + Dataset JSON-LD');


### PR DESCRIPTION
The leaderboard SPA was invisible to AI crawlers. Adds a post-build static fallback (dated sentence + real HTML rankings table in #root, replaced by React on mount) + Dataset JSON-LD, OG/Twitter meta, robots.txt (allow all incl. AI bots), and sitemap.xml. Build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)