### PR TITLE
Auto-deploy HF Space + fix weekly refresh triggers

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -1,0 +1,58 @@
+name: Deploy HF Space
+
+# Keep the Hugging Face Space in sync with the site + latest results.
+# Runs after each weekly benchmark ("Run benchmarks") completes (workflow_run fires even
+# though that job commits via GITHUB_TOKEN, which would NOT trigger `on: push`), and on
+# site/output changes to main. Requires an HF_TOKEN repo secret (write-scoped).
+on:
+  workflow_run:
+    workflows: ["Run benchmarks"]
+    types: [completed]
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "output/**"
+      - ".github/workflows/deploy-hf-space.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: hf-space
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install
+        working-directory: site
+        run: npm ci
+      - name: Build for HF (served from root)
+        working-directory: site
+        run: SITE_BASE=/ npm run build
+      - name: Push to Hugging Face Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::warning::HF_TOKEN secret not set — skipping Space deploy."
+            exit 0
+          fi
+          rm -rf hf-space
+          git clone "https://ceaustin117:$HF_TOKEN@huggingface.co/spaces/ceaustin117/ai-egg-index" hf-space
+          rm -rf hf-space/assets hf-space/data
+          cp -r site/dist/* hf-space/
+          cp site/hf-space-README.md hf-space/README.md
+          cd hf-space
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add -A
+          git diff --staged --quiet && { echo "No changes."; exit 0; }
+          git commit -m "Sync leaderboard $(date -u +%Y-%m-%d)"
+          git push

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -3,6 +3,11 @@ name: Deploy site
 # Rebuild the project's GitHub Pages leaderboard whenever the site code changes or a new
 # weekly benchmark run commits fresh data to output/.
 on:
+  # The weekly "Run benchmarks" job commits results via GITHUB_TOKEN, which does NOT
+  # trigger `on: push` — so chain off its completion to actually refresh the site weekly.
+  workflow_run:
+    workflows: ["Run benchmarks"]
+    types: [completed]
   push:
     branches: [main]
     paths:

--- a/site/hf-space-README.md
+++ b/site/hf-space-README.md
@@ -1,0 +1,23 @@
+---
+title: AI Egg Index
+emoji: 🥚
+colorFrom: yellow
+colorTo: blue
+sdk: static
+pinned: true
+short_description: The everyday index for AI — a free-tier LLM benchmark
+tags:
+- leaderboard
+- benchmark
+- llm
+- evaluation
+---
+
+# AI Egg Index
+
+The everyday index for AI — benchmarking **free-tier LLMs on everyday tasks**, updated weekly.
+
+- Code: https://github.com/Ceaustin117/ai-egg-index
+- Results dataset: https://huggingface.co/datasets/ceaustin117/ai-egg-index
+
+Scores are small-sample / directional — see the repo's LIMITATIONS.md.


### PR DESCRIPTION
Adds deploy-hf-space.yml (rebuilds + pushes the site to the HF Space after each weekly run; needs HF_TOKEN secret) and fixes both deploy workflows to trigger via workflow_run of 'Run benchmarks' — the weekly job commits with GITHUB_TOKEN which doesn't fire on:push, so the site/Space weren't actually refreshing weekly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)