### PR TITLE
Add egg banner to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="site/public/og.png" alt="AI Egg Index" width="720">
+</p>
+
 # AI Egg Index
 
 Benchmarking free-tier LLMs on tasks regular people actually care about.


### PR DESCRIPTION
Uses the tech-egg og.png as a centered README banner so the repo reads as finished.