### PR TITLE
Rank Overall on the two custom benchmarks + coverage guard

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -11,11 +11,14 @@ few points between models is likely noise, not a real difference. We don't yet r
 formal confidence intervals; until we do, treat close scores as ties. (Reference for
 where we're headed: Miller, *Adding Error Bars to Evals*, arXiv:2411.00640.)
 
-## The cross-model "overall" isn't perfectly apples-to-apples
+## The "overall" ranks on the two custom benchmarks
 
-The overall score averages whichever benchmarks a model actually ran. Because the
-OpenBench benchmarks (IFEval, GSM8K) only run on some providers (see below), a model's
-overall may average 4 benchmarks or 2. Compare per-benchmark columns for a fairer read.
+To keep the ranking comparable across providers, **overall = the mean of Practical
+Knowledge + Creative-Technical** — the two benchmarks *every* provider runs. IFEval and
+GSM8K are shown as columns but **not** folded into the overall (they only run on
+Groq/Cohere, so including them would rank models on unequal benchmark sets). A model
+that's missing either custom benchmark in a given week is shown but left **unranked**
+(`—`) rather than ranked on a single score.
 
 ## OpenBench benchmarks run on Groq + Cohere only
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Benchmarking free-tier LLMs on tasks regular people actually care about.
 
 <!-- RESULTS:START -->
 
-_Updated 2026-07-12 · small-sample, directional · `—` = not run for that provider, `N/A` = errored that run._
+_Updated 2026-07-12 · small-sample, directional · Overall = Practical + Creative (the benchmarks every provider runs); a model needs both to be ranked · `—` = not run / not ranked, `N/A` = errored that run._
 
 | Model | Provider | Practical | IFEval | GSM8K | Creative | Overall |
 |---|---|---|---|---|---|---|
-| llama-3.1-8b-instant | groq | 63% | 100% | 67% | 66% | **74%** |
-| Meta-Llama-3-8B-Instruct | huggingface | 66% | — | — | N/A | **66%** |
-| command-r-08-2024 | cohere | 56% | 33% | 100% | 62% | **63%** |
+| llama-3.1-8b-instant | groq | 63% | 100% | 67% | 66% | **64%** |
+| command-r-08-2024 | cohere | 56% | 33% | 100% | 62% | **59%** |
 | gemini-2.5-flash | google | 56% | — | — | 2% | **29%** |
+| Meta-Llama-3-8B-Instruct | huggingface | 66% | — | — | N/A | — |
 
 <!-- RESULTS:END -->
 

--- a/output/weekly-recap.md
+++ b/output/weekly-recap.md
@@ -1,14 +1,15 @@
-## 🥚 This Week's Egg Winner: llama-3.1-8b-instant (74%)
+## 🥚 This Week's Egg Winner: llama-3.1-8b-instant (64%)
 
 _Free-tier LLMs on everyday tasks — week of 2026-07-12._
 
 **Rankings (overall):**
-1. **llama-3.1-8b-instant** (groq) — 74%
-2. **Meta-Llama-3-8B-Instruct** (huggingface) — 66%
-3. **command-r-08-2024** (cohere) — 63%
-4. **gemini-2.5-flash** (google) — 29%
+1. **llama-3.1-8b-instant** (groq) — 64%
+2. **command-r-08-2024** (cohere) — 59%
+3. **gemini-2.5-flash** (google) — 29%
 
-**Biggest mover:** llama-3.1-8b-instant ▲ 65% → 70% (+5 pts)
+_Unranked this week (missing a custom benchmark):_ Meta-Llama-3-8B-Instruct (huggingface)
+
+**Biggest mover:** llama-3.1-8b-instant ▲ 52% → 56% (+4 pts)
 
 _Small-sample, directional — don't over-read a few points._
 

--- a/scripts/update_readme_table.py
+++ b/scripts/update_readme_table.py
@@ -30,19 +30,33 @@ def cell(b: dict | None) -> str:
     return f"{round(b['score'] * 100)}%"
 
 
-def overall(benchmarks: dict) -> float:
+# Overall ranks on the two custom benchmarks EVERY provider runs (apples-to-apples).
+# IFEval/GSM8K are shown as columns but excluded from the ranking, because they only run
+# on Groq/Cohere — folding them in would let a model's overall average a different
+# (smaller) benchmark set and rank unfairly.
+OVERALL_KEYS = ("practical_knowledge", "creative_technical")
+
+
+def overall(benchmarks: dict):
+    """Mean of the custom benchmarks, but only if the model has ALL of them (a valid
+    score for both). Missing/errored → None (shown but unranked), so a model can't top
+    the board on a single benchmark."""
     vals = [
-        v["score"]
-        for v in benchmarks.values()
-        if isinstance(v, dict) and isinstance(v.get("score"), (int, float))
+        benchmarks[k]["score"]
+        for k in OVERALL_KEYS
+        if isinstance(benchmarks.get(k), dict)
+        and isinstance(benchmarks[k].get("score"), (int, float))
     ]
-    return sum(vals) / len(vals) if vals else 0.0
+    return sum(vals) / len(vals) if len(vals) == len(OVERALL_KEYS) else None
 
 
 def main() -> None:
     data = json.loads(LATEST.read_text(encoding="utf-8"))
+    # Ranked models (both customs) first, by overall desc; unranked (partial) last.
     models = sorted(
-        data["models"], key=lambda m: overall(m.get("benchmarks", {})), reverse=True
+        data["models"],
+        key=lambda m: (overall(m.get("benchmarks", {})) is not None, overall(m.get("benchmarks", {})) or 0),
+        reverse=True,
     )
     lines = [
         "| Model | Provider | Practical | IFEval | GSM8K | Creative | Overall |",
@@ -50,14 +64,16 @@ def main() -> None:
     ]
     for m in models:
         bs = m.get("benchmarks", {})
+        ov = overall(bs)
         row = [m["model"].split("/")[-1], m.get("provider", "")]
         row += [cell(bs.get(k)) for k, _ in BENCHES]
-        row.append(f"**{round(overall(bs) * 100)}%**")
+        row.append(f"**{round(ov * 100)}%**" if ov is not None else "—")
         lines.append("| " + " | ".join(row) + " |")
     table = "\n".join(lines)
     note = (
         f"_Updated {data.get('last_updated', '')} · small-sample, directional · "
-        "`—` = not run for that provider, `N/A` = errored that run._"
+        "Overall = Practical + Creative (the benchmarks every provider runs); a model needs "
+        "both to be ranked · `—` = not run / not ranked, `N/A` = errored that run._"
     )
     block = f"{START}\n\n{note}\n\n{table}\n\n{END}"
     text = README.read_text(encoding="utf-8")

--- a/scripts/weekly_recap.py
+++ b/scripts/weekly_recap.py
@@ -25,25 +25,39 @@ def _mean(values) -> float | None:
     return sum(nums) / len(nums) if nums else None
 
 
+# Overall ranks on the two custom benchmarks every provider runs (Practical + Creative);
+# IFEval/GSM8K only run on Groq/Cohere, so including them would rank on unequal sets.
+OVERALL = ["practical_knowledge", "creative_technical"]
+
+
 def overall_latest(model: dict) -> float | None:
-    return _mean([b.get("score") for b in model.get("benchmarks", {}).values() if isinstance(b, dict)])
+    # Ranked only if the model has BOTH custom benchmarks (no crowning on a single score).
+    b = model.get("benchmarks", {})
+    scores = [
+        b[k].get("score")
+        for k in OVERALL
+        if isinstance(b.get(k), dict) and isinstance(b[k].get("score"), (int, float))
+    ]
+    return sum(scores) / len(scores) if len(scores) == len(OVERALL) else None
 
 
 def overall_hist(entry: dict) -> float | None:
-    return _mean([entry.get(k) for k in BENCH])
+    return _mean([entry.get(k) for k in OVERALL])
 
 
 def main() -> None:
     latest = json.loads(LATEST.read_text(encoding="utf-8"))
     date = latest.get("last_updated", "")
+    models = latest.get("models", [])
     ranked = sorted(
-        ((overall_latest(m) or 0.0, m) for m in latest.get("models", [])),
+        ((overall_latest(m), m) for m in models if overall_latest(m) is not None),
         key=lambda x: x[0],
         reverse=True,
     )
+    partial = [m for m in models if overall_latest(m) is None]
     if not ranked:
-        OUT.write_text("_No results yet._\n", encoding="utf-8")
-        print("No results yet.")
+        OUT.write_text("_No ranked results this week._\n", encoding="utf-8")
+        print("No ranked results this week.")
         return
 
     winner_score, winner = ranked[0]
@@ -73,6 +87,10 @@ def main() -> None:
     ]
     for i, (o, m) in enumerate(ranked, 1):
         lines.append(f"{i}. **{short(m['model'])}** ({m.get('provider', '')}) — {round(o * 100)}%")
+
+    if partial:
+        names = ", ".join(f"{short(m['model'])} ({m.get('provider', '')})" for m in partial)
+        lines += ["", f"_Unranked this week (missing a custom benchmark):_ {names}"]
 
     if mover:
         delta, m, prev, cur = mover

--- a/site/scripts/inject-static.mjs
+++ b/site/scripts/inject-static.mjs
@@ -26,19 +26,30 @@ const BENCH = [
 ];
 const esc = (s) =>
   String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+// Overall = the two custom benchmarks every provider runs (IFEval/GSM8K are Groq/Cohere-only).
+// null unless the model has BOTH — so it can't rank on a single benchmark.
+const OVERALL_KEYS = ['practical_knowledge', 'creative_technical'];
 const overall = (b) => {
-  const v = Object.values(b || {}).filter((x) => x && typeof x.score === 'number').map((x) => x.score);
-  return v.length ? v.reduce((a, c) => a + c, 0) / v.length : 0;
+  const v = OVERALL_KEYS.map((k) => b && b[k]).filter((x) => x && typeof x.score === 'number').map((x) => x.score);
+  return v.length === OVERALL_KEYS.length ? v.reduce((a, c) => a + c, 0) / v.length : null;
 };
 const cell = (x) => (x == null ? '—' : x.status === 'error' || x.score == null ? 'N/A' : Math.round(x.score * 100) + '%');
 
-const models = [...data.models].sort((a, b) => overall(b.benchmarks) - overall(a.benchmarks));
-const top = models[0];
+// Ranked models (both customs) first by overall desc; unranked (null) sorted last.
+const models = [...data.models].sort((a, b) => {
+  const oa = overall(a.benchmarks), ob = overall(b.benchmarks);
+  if (oa === null && ob === null) return 0;
+  if (oa === null) return 1;
+  if (ob === null) return -1;
+  return ob - oa;
+});
+const top = models.find((m) => overall(m.benchmarks) !== null) || models[0];
 const rows = models
   .map((m) => {
     const b = m.benchmarks || {};
+    const o = overall(b);
     const tds = BENCH.map(([k]) => `<td>${cell(b[k])}</td>`).join('');
-    return `<tr><td>${esc(m.model.split('/').pop())}</td><td>${esc(m.provider || '')}</td>${tds}<td><strong>${Math.round(overall(b) * 100)}%</strong></td></tr>`;
+    return `<tr><td>${esc(m.model.split('/').pop())}</td><td>${esc(m.provider || '')}</td>${tds}<td><strong>${o === null ? '—' : Math.round(o * 100) + '%'}</strong></td></tr>`;
   })
   .join('');
 

--- a/site/src/components/BenchmarkComparer.tsx
+++ b/site/src/components/BenchmarkComparer.tsx
@@ -34,6 +34,9 @@ const BENCHMARK_INFO: Record<string, { name: string; description: string; catego
 };
 
 const BENCHMARK_KEYS = ['practical_knowledge', 'ifeval', 'gsm8k', 'creative_technical'] as const;
+// Overall ranks only on the custom benchmarks every provider runs; IFEval/GSM8K are shown
+// as columns but excluded (they're Groq/Cohere-only, so they'd rank on unequal sets).
+const OVERALL_KEYS = ['practical_knowledge', 'creative_technical'] as const;
 
 const BenchmarkComparer: React.FC<BenchmarkComparerProps> = ({ data, historicalData }) => {
   const [sortField, setSortField] = useState<SortField>('overall');
@@ -46,10 +49,14 @@ const BenchmarkComparer: React.FC<BenchmarkComparerProps> = ({ data, historicalD
     return ['all', ...uniqueProviders.sort()];
   }, [data]);
 
+  // NaN (unranked) unless the model has BOTH custom benchmarks — so it can't rank on one.
   const calculateOverall = (model: BenchmarkResult): number => {
-    const scores = BENCHMARK_KEYS.map(key => model.benchmarks[key]?.score ?? 0);
-    const validScores = scores.filter(s => s > 0);
-    return validScores.length > 0 ? validScores.reduce((a, b) => a + b, 0) / validScores.length : 0;
+    const scores = OVERALL_KEYS
+      .map(key => model.benchmarks[key]?.score)
+      .filter((s): s is number => typeof s === 'number' && s > 0);
+    return scores.length === OVERALL_KEYS.length
+      ? scores.reduce((a, b) => a + b, 0) / scores.length
+      : NaN;
   };
 
   const getScoreClass = (score: number): string => {
@@ -109,8 +116,10 @@ const BenchmarkComparer: React.FC<BenchmarkComparerProps> = ({ data, historicalD
         aVal = a[sortField].toLowerCase();
         bVal = b[sortField].toLowerCase();
       } else if (sortField === 'overall') {
-        aVal = calculateOverall(a);
-        bVal = calculateOverall(b);
+        // Unranked (NaN) models sort last.
+        const ao = calculateOverall(a), bo = calculateOverall(b);
+        aVal = Number.isNaN(ao) ? -Infinity : ao;
+        bVal = Number.isNaN(bo) ? -Infinity : bo;
       } else {
         aVal = a.benchmarks[sortField]?.score ?? 0;
         bVal = b.benchmarks[sortField]?.score ?? 0;
@@ -214,7 +223,11 @@ const BenchmarkComparer: React.FC<BenchmarkComparerProps> = ({ data, historicalD
                   {renderSortIndicator(key as SortField)}
                 </th>
               ))}
-              <th onClick={() => handleSort('overall')} className="sortable overall-header">
+              <th
+                onClick={() => handleSort('overall')}
+                className="sortable overall-header"
+                title="Overall = Practical + Creative, the benchmarks every provider runs. IFEval/GSM8K are shown but not included (they run on Groq/Cohere only)."
+              >
                 Overall{renderSortIndicator('overall')}
               </th>
             </tr>
@@ -270,8 +283,13 @@ const BenchmarkComparer: React.FC<BenchmarkComparerProps> = ({ data, historicalD
                       </td>
                     );
                   })}
-                  <td className={`score-cell overall-cell ${unavailable ? 'score-unavailable' : getScoreClass(overall)}`}>
-                    <span className="score-value overall-value">{unavailable ? 'N/A' : formatScore(overall)}</span>
+                  <td
+                    className={`score-cell overall-cell ${unavailable || Number.isNaN(overall) ? 'score-unavailable' : getScoreClass(overall)}`}
+                    title={Number.isNaN(overall) && !unavailable ? 'Unranked: missing a custom benchmark (Practical or Creative) this run.' : undefined}
+                  >
+                    <span className="score-value overall-value">
+                      {unavailable ? 'N/A' : Number.isNaN(overall) ? '—' : formatScore(overall)}
+                    </span>
                   </td>
                 </tr>
               );

--- a/site/src/components/PerformanceTrend.tsx
+++ b/site/src/components/PerformanceTrend.tsx
@@ -6,21 +6,17 @@ interface PerformanceTrendProps {
   data: HistoricalData;
 }
 
-const BENCH_KEYS: (keyof HistoricalScoreEntry)[] = [
-  'practical_knowledge',
-  'ifeval',
-  'gsm8k',
-  'creative_technical',
-];
+// Overall = the two custom benchmarks every provider runs (IFEval/GSM8K are Groq/Cohere-only).
+const OVERALL_KEYS: (keyof HistoricalScoreEntry)[] = ['practical_knowledge', 'creative_technical'];
 
 const LINE_COLORS = ['#06b6d4', '#fbbf24', '#a78bfa', '#34d399', '#f87171', '#f472b6'];
 
 const shortModel = (m: string) => m.split('/').pop() || m;
 
-/** Overall (composite) score for one historical entry: mean of the benchmarks present. */
+/** Overall score for one historical entry: mean of the custom benchmarks present. */
 function overallOf(entry: HistoricalScoreEntry): number | null {
-  const vals = BENCH_KEYS.map((k) => entry[k]).filter((v): v is number => typeof v === 'number');
-  if (!vals.length) return null;
+  const vals = OVERALL_KEYS.map((k) => entry[k]).filter((v): v is number => typeof v === 'number');
+  if (vals.length !== OVERALL_KEYS.length) return null;
   return vals.reduce((a, b) => a + b, 0) / vals.length;
 }
 

--- a/site/src/vite-env.d.ts
+++ b/site/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Overall now = mean of Practical + Creative (the benchmarks every provider runs); IFEval/GSM8K shown but excluded (Groq/Cohere-only). A model needs BOTH customs to be ranked, else shown unranked (—). Fixes the misleading ranking where a model topped the board on a single benchmark. Applied consistently across README table, recap, and site (table + chart + static fallback). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)